### PR TITLE
[EAGLE-687] updating SiteEntityToRelation to accept null values

### DIFF
--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/service/orm/SiteEntityToRelation.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/service/orm/SiteEntityToRelation.java
@@ -29,15 +29,17 @@ public class SiteEntityToRelation implements ThrowableConsumer2<PreparedStatemen
     @Override
     public void accept(PreparedStatement statement, SiteEntity entity) throws SQLException {
         int parameterIndex = 1;
-        if (StringUtils.isNotBlank(entity.getSiteId())) {
+        boolean addNullValue = (statement.getParameterMetaData().getParameterCount() > 5);
+
+        if (addNullValue || StringUtils.isNotBlank(entity.getSiteId())) {
             statement.setString(parameterIndex, entity.getSiteId());
             parameterIndex++;
         }
-        if (StringUtils.isNotBlank(entity.getSiteName())) {
+        if (addNullValue || StringUtils.isNotBlank(entity.getSiteName())) {
             statement.setString(parameterIndex, entity.getSiteName());
             parameterIndex++;
         }
-        if (StringUtils.isNotBlank(entity.getDescription())) {
+        if (addNullValue || StringUtils.isNotBlank(entity.getDescription())) {
             statement.setString(parameterIndex, entity.getDescription());
             parameterIndex++;
         }

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/java/org/apache/eagle/metadata/store/jdbc/SiteEntityServiceJDBCImplTest.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/java/org/apache/eagle/metadata/store/jdbc/SiteEntityServiceJDBCImplTest.java
@@ -52,7 +52,27 @@ public class SiteEntityServiceJDBCImplTest extends JDBCMetadataTestBase {
         Assert.assertEquals("testdesc", siteEntityFromDB.getDescription());
         Assert.assertEquals(createdTime, siteEntityFromDB.getCreatedTime());
         Assert.assertEquals(modifiedTime, siteEntityFromDB.getModifiedTime());
+    }
 
+    @Test
+    public void testInsertSiteEntityWithNullValues() throws SQLException {
+        SiteEntity siteEntity = new SiteEntity();
+        siteEntity.setSiteId("test-null-site");
+
+        siteEntityService.create(siteEntity);
+        String uuid = siteEntity.getUuid();
+        long createdTime = siteEntity.getCreatedTime();
+        long modifiedTime = siteEntity.getModifiedTime();
+
+        Collection<SiteEntity> results = siteEntityService.findAll();
+        Assert.assertEquals(1, results.size());
+        SiteEntity siteEntityFromDB = results.iterator().next();
+        Assert.assertEquals(uuid, siteEntityFromDB.getUuid());
+        Assert.assertEquals("test-null-site", siteEntityFromDB.getSiteId());
+        Assert.assertNull(siteEntityFromDB.getSiteName());
+        Assert.assertNull(siteEntityFromDB.getDescription());
+        Assert.assertEquals(createdTime, siteEntityFromDB.getCreatedTime());
+        Assert.assertEquals(modifiedTime, siteEntityFromDB.getModifiedTime());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Currently if you create site with any of the field set to NULL, it will throw 
explored the way to use preparedStatements with explicitly specified parameters but that would require quite a large refactoring on entire metadata module.
so came up with the fix that is based on current assumptions in SiteEntityServiceJDBCImpl which is forming the sql in particular way that suits in SiteEntityToRelation.accept method.