### PR TITLE
EAGLE-852 Application start button should be disabled when it's running, and the same for stop button.

### DIFF
--- a/eagle-hadoop-metric/pom.xml
+++ b/eagle-hadoop-metric/pom.xml
@@ -45,6 +45,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>eagle-topology-app</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/eagle-hadoop-metric/src/test/java/org/apache/eagle/metric/HadoopMetricMonitorAppProviderTest.java
+++ b/eagle-hadoop-metric/src/test/java/org/apache/eagle/metric/HadoopMetricMonitorAppProviderTest.java
@@ -55,6 +55,11 @@ public class HadoopMetricMonitorAppProviderTest extends ApplicationTestBase {
 
         ApplicationOperations.InstallOperation installOperation = new ApplicationOperations.InstallOperation("test_site", "HADOOP_METRIC_MONITOR", ApplicationEntity.Mode.LOCAL);
         installOperation.setConfiguration(getConf());
+
+        //Install dependency
+        ApplicationOperations.InstallOperation installOperationDependency = new ApplicationOperations.InstallOperation("test_site", "TOPOLOGY_HEALTH_CHECK_APP", ApplicationEntity.Mode.LOCAL);
+        applicationResource.installApplication(installOperationDependency);
+
         // Install application
         ApplicationEntity applicationEntity = applicationResource.installApplication(installOperation).getData();
         // Uninstall application

--- a/eagle-server/src/main/webapp/app/dev/partials/integration/site.html
+++ b/eagle-server/src/main/webapp/app/dev/partials/integration/site.html
@@ -62,10 +62,16 @@
 				<td class="text-center">
 					<div class="btn-group btn-group-xs" ng-if="app.installed">
 						<!--button class="btn btn-default btn-sm">Monitor</button-->
-						<button class="btn btn-default btn-sm" ng-click="startApp(app)" ng-if="app.descriptor.executable">
+						<button class="btn btn-default btn-sm" ng-click="startApp(app)" ng-if="app.descriptor.executable && app.status === 'INITIALIZED'">
 							<span class="fa fa-play"></span>
 						</button>
-						<button class="btn btn-default btn-sm" ng-click="stopApp(app)" ng-if="app.descriptor.executable">
+						<button class="btn btn-default btn-sm" disabled="disabled" ng-if="app.descriptor.executable && app.status !== 'INITIALIZED'">
+							<span class="fa fa-play"></span>
+						</button>
+						<button class="btn btn-default btn-sm" ng-click="stopApp(app)" ng-if="app.descriptor.executable && app.status === 'RUNNING'">
+							<span class="fa fa-stop"></span>
+						</button>
+						<button class="btn btn-default btn-sm" disabled="disabled" ng-if="app.descriptor.executable && app.status !== 'RUNNING'">
 							<span class="fa fa-stop"></span>
 						</button>
 						<button class="btn btn-default btn-sm" disabled="disabled" ng-if="!app.descriptor.executable">


### PR DESCRIPTION
EAGLE-852 Application start button should be disabled when it's running, and the same for stop button.
- Add disabled judgment logic.

executable | status  | start button | stop button
---|--- | --- | ---
Y | INITIALIZED | Y | N
Y | STARTING | N | N
Y | RUNNING | N | Y
Y | STOPPING | N | N
Y | STOPPED | N | N
N | INITIALIZED | N | N

https://issues.apache.org/jira/browse/EAGLE-852