### PR TITLE
[MINOR] Fix license header missing in eagle-jpm-analyzer

### DIFF
--- a/eagle-jpm/eagle-jpm-analyzer/pom.xml
+++ b/eagle-jpm/eagle-jpm-analyzer/pom.xml
@@ -1,4 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/eagle-jpm/eagle-jpm-analyzer/src/main/resources/createTable.sql
+++ b/eagle-jpm/eagle-jpm-analyzer/src/main/resources/createTable.sql
@@ -1,3 +1,21 @@
+-- /*
+--  * Licensed to the Apache Software Foundation (ASF) under one or more
+--  * contributor license agreements.  See the NOTICE file distributed with
+--  * this work for additional information regarding copyright ownership.
+--  * The ASF licenses this file to You under the Apache License, Version 2.0
+--  * (the "License"); you may not use this file except in compliance with
+--  * the License.  You may obtain a copy of the License at
+--  *
+--  *    http://www.apache.org/licenses/LICENSE-2.0
+--  *
+--  * Unless required by applicable law or agreed to in writing, software
+--  * distributed under the License is distributed on an "AS IS" BASIS,
+--  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  * See the License for the specific language governing permissions and
+--  * limitations under the License.
+--  *
+--  */
+
 CREATE TABLE IF NOT EXISTS jobs (
   jobDefId VARCHAR(50) NOT NULL,
   configuration MEDIUMTEXT NOT NULL,


### PR DESCRIPTION
Fix license header missing in eagle-jpm-analyzer
* eagle-jpm/eagle-jpm-analyzer/pom.xml
* eagle-jpm/eagle-jpm-analyzer/src/main/resources/createTable.sql