### PR TITLE
[MINOR] Fix unit test cases caused by forcefully using fasterxml-jackson

### DIFF
--- a/eagle-core/eagle-query/eagle-client-base/src/main/java/org/apache/eagle/service/client/impl/EagleServiceClientImpl.java
+++ b/eagle-core/eagle-query/eagle-client-base/src/main/java/org/apache/eagle/service/client/impl/EagleServiceClientImpl.java
@@ -33,11 +33,11 @@ import java.util.List;
 import java.util.Map;
 
 public class EagleServiceClientImpl extends EagleServiceBaseClient {
-    private final static Logger LOG = LoggerFactory.getLogger(EagleServiceClientImpl.class);
-    private final static String SERVICE_HOST_KEY = "service.host";
-    private final static String SERVICE_PORT_KEY = "service.port";
-    private final static String SERVICE_USERNAME_KEY = "service.username";
-    private final static String SERVICE_PASSWORD_KEY = "service.password";
+    private static final Logger LOG = LoggerFactory.getLogger(EagleServiceClientImpl.class);
+    private static final String SERVICE_HOST_KEY = "service.host";
+    private static final String SERVICE_PORT_KEY = "service.port";
+    private static final String SERVICE_USERNAME_KEY = "service.username";
+    private static final String SERVICE_PASSWORD_KEY = "service.password";
 
     public EagleServiceClientImpl(String host, int port) {
         super(host, port);
@@ -61,11 +61,11 @@ public class EagleServiceClientImpl extends EagleServiceBaseClient {
      * Try to get eagle service port from config by key: service.port no matter STRING or INT.
      */
     private static int tryGetPortFromConfig(Config config) {
-        if (config.hasPath("service.port")) {
+        if (config.hasPath(SERVICE_PORT_KEY)) {
             try {
-                return config.getInt("service.port");
+                return config.getInt(SERVICE_PORT_KEY);
             } catch (ConfigException.WrongType wrongType) {
-                return Integer.valueOf(config.getString("service.port"));
+                return Integer.valueOf(config.getString(SERVICE_PORT_KEY));
             }
         } else {
             return 9090;

--- a/eagle-core/eagle-query/eagle-client-base/src/main/java/org/apache/eagle/service/client/impl/EagleServiceClientImpl.java
+++ b/eagle-core/eagle-query/eagle-client-base/src/main/java/org/apache/eagle/service/client/impl/EagleServiceClientImpl.java
@@ -16,13 +16,14 @@
  */
 package org.apache.eagle.service.client.impl;
 
+import com.sun.jersey.api.client.WebResource;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 import org.apache.eagle.log.base.taggedlog.TaggedLogAPIEntity;
 import org.apache.eagle.log.entity.GenericServiceAPIResponseEntity;
 import org.apache.eagle.service.client.EagleServiceClientException;
 import org.apache.eagle.service.client.EagleServiceConnector;
 import org.apache.eagle.service.client.EagleServiceSingleEntityQueryRequest;
-import com.sun.jersey.api.client.WebResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,10 @@ import java.util.Map;
 
 public class EagleServiceClientImpl extends EagleServiceBaseClient {
     private final static Logger LOG = LoggerFactory.getLogger(EagleServiceClientImpl.class);
+    private final static String SERVICE_HOST_KEY = "service.host";
+    private final static String SERVICE_PORT_KEY = "service.port";
+    private final static String SERVICE_USERNAME_KEY = "service.username";
+    private final static String SERVICE_PASSWORD_KEY = "service.password";
 
     public EagleServiceClientImpl(String host, int port) {
         super(host, port);
@@ -43,31 +48,46 @@ public class EagleServiceClientImpl extends EagleServiceBaseClient {
         this(connector.getEagleServiceHost(), connector.getEagleServicePort(), connector.getUsername(), connector.getPassword());
     }
 
-    public EagleServiceClientImpl (Config config) {
+    public EagleServiceClientImpl(Config config) {
         super(
-            config.hasPath("service.host") ? config.getString("service.host") : "localhost",
-            config.hasPath("service.port") ? config.getInt("service.port") : 9090,
-            config.hasPath("service.username") ? config.getString("service.username") : null,
-            config.hasPath("service.password") ? config.getString("service.password") : null
+            config.hasPath(SERVICE_HOST_KEY) ? config.getString(SERVICE_HOST_KEY) : "localhost",
+            tryGetPortFromConfig(config),
+            config.hasPath(SERVICE_USERNAME_KEY) ? config.getString(SERVICE_USERNAME_KEY) : null,
+            config.hasPath(SERVICE_PASSWORD_KEY) ? config.getString(SERVICE_PASSWORD_KEY) : null
         );
     }
 
-    public EagleServiceClientImpl(String host, int port, String username, String password){
+    /**
+     * Try to get eagle service port from config by key: service.port no matter STRING or INT.
+     */
+    private static int tryGetPortFromConfig(Config config) {
+        if (config.hasPath("service.port")) {
+            try {
+                return config.getInt("service.port");
+            } catch (ConfigException.WrongType wrongType) {
+                return Integer.valueOf(config.getString("service.port"));
+            }
+        } else {
+            return 9090;
+        }
+    }
+
+    public EagleServiceClientImpl(String host, int port, String username, String password) {
         super(host, port, username, password);
     }
 
-    public EagleServiceClientImpl(String host, int port, String basePath, String username, String password){
+    public EagleServiceClientImpl(String host, int port, String basePath, String username, String password) {
         super(host, port, basePath, username, password);
     }
 
-    private String getWholePath(String urlString){
-    	return getBaseEndpoint() + urlString;
+    private String getWholePath(String urlString) {
+        return getBaseEndpoint() + urlString;
     }
 
     @Override
-    public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> create(List<E> entities, String serviceName) throws IOException,EagleServiceClientException {
-        checkNotNull(serviceName,"serviceName");
-        checkNotNull(entities,"entities");
+    public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> create(List<E> entities, String serviceName) throws IOException, EagleServiceClientException {
+        checkNotNull(serviceName, "serviceName");
+        checkNotNull(entities, "entities");
 
         final GenericServiceAPIResponseEntity<String> response;
         response = postEntitiesWithService(GENERIC_ENTITY_PATH, entities, serviceName);
@@ -79,18 +99,20 @@ public class EagleServiceClientImpl extends EagleServiceBaseClient {
 
     @Override
     public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> create(List<E> entities) throws IOException, EagleServiceClientException {
-        checkNotNull(entities,"entities");
+        checkNotNull(entities, "entities");
 
-        Map<String,List<E>> serviceEntityMap = groupEntitiesByService(entities);
-        if(LOG.isDebugEnabled()) LOG.debug("Creating entities for "+serviceEntityMap.keySet().size()+" services");
+        Map<String, List<E>> serviceEntityMap = groupEntitiesByService(entities);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Creating entities for " + serviceEntityMap.keySet().size() + " services");
+        }
 
         List<String> createdKeys = new LinkedList<String>();
 
-        for(Map.Entry<String,List<E>> entry: serviceEntityMap.entrySet()){
-            GenericServiceAPIResponseEntity<String> response = create(entry.getValue(),entry.getKey());
-            if(!response.isSuccess()){
-                throw new IOException("Service side exception: "+response.getException());
-            }else if(response.getObj()!=null){
+        for (Map.Entry<String, List<E>> entry : serviceEntityMap.entrySet()) {
+            GenericServiceAPIResponseEntity<String> response = create(entry.getValue(), entry.getKey());
+            if (!response.isSuccess()) {
+                throw new IOException("Service side exception: " + response.getException());
+            } else if (response.getObj() != null) {
                 createdKeys.addAll(response.getObj());
             }
         }
@@ -102,18 +124,20 @@ public class EagleServiceClientImpl extends EagleServiceBaseClient {
 
     @Override
     public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> delete(List<E> entities) throws IOException, EagleServiceClientException {
-        checkNotNull(entities,"entities");
+        checkNotNull(entities, "entities");
 
-        Map<String,List<E>> serviceEntityMap = groupEntitiesByService(entities);
-        if(LOG.isDebugEnabled()) LOG.debug("Creating entities for "+serviceEntityMap.keySet().size()+" services");
+        Map<String, List<E>> serviceEntityMap = groupEntitiesByService(entities);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Creating entities for " + serviceEntityMap.keySet().size() + " services");
+        }
 
         List<String> deletedKeys = new LinkedList<String>();
-        for(Map.Entry<String,List<E>> entry: serviceEntityMap.entrySet()){
+        for (Map.Entry<String, List<E>> entry : serviceEntityMap.entrySet()) {
             GenericServiceAPIResponseEntity<String> response = delete(entry.getValue(), entry.getKey());
-            if(!response.isSuccess()){
-                LOG.error("Got service exception: "+response.getException());
+            if (!response.isSuccess()) {
+                LOG.error("Got service exception: " + response.getException());
                 throw new IOException(response.getException());
-            }else if(response.getObj()!=null){
+            } else if (response.getObj() != null) {
                 deletedKeys.addAll(response.getObj());
             }
         }
@@ -125,60 +149,64 @@ public class EagleServiceClientImpl extends EagleServiceBaseClient {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> delete(List<E> entities, String serviceName) throws IOException,EagleServiceClientException {
-        checkNotNull(entities,"entities");
-        checkNotNull(serviceName,"serviceName");
+    public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> delete(List<E> entities, String serviceName) throws IOException, EagleServiceClientException {
+        checkNotNull(entities, "entities");
+        checkNotNull(serviceName, "serviceName");
 
-        return postEntitiesWithService(GENERIC_ENTITY_DELETE_PATH,entities,serviceName);
+        return postEntitiesWithService(GENERIC_ENTITY_DELETE_PATH, entities, serviceName);
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public GenericServiceAPIResponseEntity<String> delete(EagleServiceSingleEntityQueryRequest request) throws IOException,EagleServiceClientException {
+    public GenericServiceAPIResponseEntity<String> delete(EagleServiceSingleEntityQueryRequest request) throws IOException, EagleServiceClientException {
         String queryString = request.getQueryParameterString();
         StringBuilder sb = new StringBuilder();
         sb.append(GENERIC_ENTITY_PATH);
         sb.append("?");
         sb.append(queryString);
-        final String urlString =  sb.toString();
+        final String urlString = sb.toString();
 
-        if(!this.silence) LOG.info("Going to delete by querying service: " + getWholePath(urlString));
+        if (!this.silence) {
+            LOG.info("Going to delete by querying service: " + getWholePath(urlString));
+        }
         WebResource r = getWebResource(urlString);
         return putAuthHeaderIfNeeded(r.accept(DEFAULT_MEDIA_TYPE)
-                                      .header(CONTENT_TYPE, DEFAULT_HTTP_HEADER_CONTENT_TYPE))
-                                      .delete(GenericServiceAPIResponseEntity.class);
+            .header(CONTENT_TYPE, DEFAULT_HTTP_HEADER_CONTENT_TYPE))
+            .delete(GenericServiceAPIResponseEntity.class);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public GenericServiceAPIResponseEntity<String> deleteById(List<String> ids, String serviceName) throws EagleServiceClientException, IOException {
-        checkNotNull(serviceName,"serviceName");
-        checkNotNull(ids,"ids");
+        checkNotNull(serviceName, "serviceName");
+        checkNotNull(ids, "ids");
 
         final String json = marshall(ids);
         final WebResource r = getWebResource(GENERIC_ENTITY_DELETE_PATH);
-        return putAuthHeaderIfNeeded(r.queryParam(SERVICE_NAME,serviceName)
-                                       .queryParam(DELETE_BY_ID, "true")
-                                       .accept(DEFAULT_MEDIA_TYPE))
-                                       .header(CONTENT_TYPE, DEFAULT_HTTP_HEADER_CONTENT_TYPE)
-                                       .post(GenericServiceAPIResponseEntity.class, json);
+        return putAuthHeaderIfNeeded(r.queryParam(SERVICE_NAME, serviceName)
+            .queryParam(DELETE_BY_ID, "true")
+            .accept(DEFAULT_MEDIA_TYPE))
+            .header(CONTENT_TYPE, DEFAULT_HTTP_HEADER_CONTENT_TYPE)
+            .post(GenericServiceAPIResponseEntity.class, json);
     }
 
     @Override
     public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> update(List<E> entities) throws IOException, EagleServiceClientException {
-        checkNotNull(entities,"entities");
+        checkNotNull(entities, "entities");
 
-        Map<String,List<E>> serviceEntityMap = groupEntitiesByService(entities);
-        if(LOG.isDebugEnabled()) LOG.debug("Updating entities for "+serviceEntityMap.keySet().size()+" services");
+        Map<String, List<E>> serviceEntityMap = groupEntitiesByService(entities);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Updating entities for " + serviceEntityMap.keySet().size() + " services");
+        }
 
         List<String> createdKeys = new LinkedList<String>();
 
-        for(Map.Entry<String,List<E>> entry: serviceEntityMap.entrySet()){
+        for (Map.Entry<String, List<E>> entry : serviceEntityMap.entrySet()) {
             GenericServiceAPIResponseEntity<String> response = update(entry.getValue(), entry.getKey());
-            if(!response.isSuccess()){
-                throw new IOException("Got service exception when updating service "+entry.getKey()+" : "+response.getException());
-            }else{
-                if(response.getObj()!=null) {
+            if (!response.isSuccess()) {
+                throw new IOException("Got service exception when updating service " + entry.getKey() + " : " + response.getException());
+            } else {
+                if (response.getObj() != null) {
                     createdKeys.addAll(response.getObj());
                 }
             }
@@ -192,10 +220,10 @@ public class EagleServiceClientImpl extends EagleServiceBaseClient {
 
     @Override
     public <E extends TaggedLogAPIEntity> GenericServiceAPIResponseEntity<String> update(List<E> entities, String serviceName) throws IOException, EagleServiceClientException {
-        checkNotNull(entities,"entities");
-        checkNotNull(serviceName,"serviceName");
+        checkNotNull(entities, "entities");
+        checkNotNull(serviceName, "serviceName");
 
-        return putEntitiesWithService(GENERIC_ENTITY_PATH,entities,serviceName);
+        return putEntitiesWithService(GENERIC_ENTITY_PATH, entities, serviceName);
     }
 
     @Override
@@ -206,11 +234,13 @@ public class EagleServiceClientImpl extends EagleServiceBaseClient {
         sb.append(GENERIC_ENTITY_PATH);
         sb.append("?");
         sb.append(queryString);
-        final String urlString =  sb.toString();
-        if(!this.silence) LOG.info("Going to query service: " + getWholePath(urlString));
+        final String urlString = sb.toString();
+        if (!this.silence) {
+            LOG.info("Going to query service: " + getWholePath(urlString));
+        }
         WebResource r = getWebResource(urlString);
         return putAuthHeaderIfNeeded(r.accept(DEFAULT_MEDIA_TYPE))
-                                       .header(CONTENT_TYPE, DEFAULT_HTTP_HEADER_CONTENT_TYPE)
-                                       .get(GenericServiceAPIResponseEntity.class);
+            .header(CONTENT_TYPE, DEFAULT_HTTP_HEADER_CONTENT_TYPE)
+            .get(GenericServiceAPIResponseEntity.class);
     }
 }

--- a/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestGenericEntityServiceResource.java
+++ b/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestGenericEntityServiceResource.java
@@ -206,7 +206,7 @@ public class TestGenericEntityServiceResource {
         Assert.assertTrue(responseEntity.isSuccess());
         Assert.assertTrue(responseEntity.getMeta().toString().startsWith("{firstTimestamp=null, totalResults=1, lastTimestamp=null, elapsedms="));
         Assert.assertEquals(null, responseEntity.getType());
-        Assert.assertEquals("{prefix=null, timestamp=" + timestamp + ", tags={cluster=test4UT, jobId=job_2, index=1, datacenter=dc1}, exp=null, encodedRowkey=null, serializeAlias=null, serializeVerbose=true, field1=1, field2=2, field3=3, field4=4, field5=5.0, field6=5.0, field7=7}", responseEntity.getObj().get(0).toString());
+        Assert.assertEquals("{timestamp=" + timestamp + ", tags={cluster=test4UT, jobId=job_2, index=1, datacenter=dc1}, serializeVerbose=true, field1=1, field2=2, field3=3, field4=4, field5=5.0, field6=5.0, field7=7}", responseEntity.getObj().get(0).toString());
         Assert.assertEquals(null, responseEntity.getException());
         verify(dataStorage).queryById(rowkeys, ed);
     }

--- a/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestResourceUnmarshal.java
+++ b/eagle-core/eagle-query/eagle-service-base/src/test/java/org/apache/eagle/service/generic/TestResourceUnmarshal.java
@@ -36,6 +36,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 
@@ -89,37 +90,17 @@ public class TestResourceUnmarshal {
         Assert.assertEquals(timeSeriesAPIEntityList.get(0).getTags().get("datacenter"), result.get(0).getTags().get("datacenter"));
         Assert.assertEquals(timeSeriesAPIEntityList.get(0).getTags().get("index"), result.get(0).getTags().get("index"));
         Assert.assertEquals(timeSeriesAPIEntityList.get(0).getTags().get("jobId"), result.get(0).getTags().get("jobId"));
-
     }
 
     @Test
     public void testUnmarshalAsStringlist() throws NoSuchMethodException, JsonProcessingException, InvocationTargetException, IllegalAccessException {
-
-        TestTimeSeriesAPIEntity timeSeriesAPIEntity = new TestTimeSeriesAPIEntity();
-        timeSeriesAPIEntity.setTimestamp(1l);
-        timeSeriesAPIEntity.setField1(1);
-        timeSeriesAPIEntity.setField2(2);
-        timeSeriesAPIEntity.setField3(3);
-        timeSeriesAPIEntity.setField4(4L);
-        timeSeriesAPIEntity.setField5(5.0);
-        timeSeriesAPIEntity.setField6(5.0);
-        timeSeriesAPIEntity.setField7("7");
-        timeSeriesAPIEntity.setTags(new HashMap<>());
-        timeSeriesAPIEntity.getTags().put("cluster", "test4UT");
-        timeSeriesAPIEntity.getTags().put("datacenter", "dc1");
-        timeSeriesAPIEntity.getTags().put("index", "" + 1);
-        timeSeriesAPIEntity.getTags().put("jobId", "job_" + timeSeriesAPIEntity.getTimestamp());
-
-        List<TestTimeSeriesAPIEntity> timeSeriesAPIEntityList = new ArrayList<>();
-        timeSeriesAPIEntityList.add(timeSeriesAPIEntity);
-
+        String[] entityIds = new String[]{"key1","key2"};
         GenericEntityServiceResource genericEntityServiceResource = new GenericEntityServiceResource();
         Method unmarshalAsStringlist = genericEntityServiceResource.getClass().getDeclaredMethod("unmarshalAsStringlist", InputStream.class);
         unmarshalAsStringlist.setAccessible(true);
 
-        InputStream stream = new ByteArrayInputStream(MAPPER.writeValueAsString(timeSeriesAPIEntityList).getBytes(StandardCharsets.UTF_8));
+        InputStream stream = new ByteArrayInputStream(MAPPER.writeValueAsString(entityIds).getBytes(StandardCharsets.UTF_8));
         List<String> result = (List<String>) unmarshalAsStringlist.invoke(genericEntityServiceResource, stream);
-
-        Assert.assertEquals("[{, prefix, null, timestamp, 1, tags, {, cluster, test4UT, jobId, job_1, index, 1, datacenter, dc1, }, exp, null, encodedRowkey, null, serializeAlias, null, serializeVerbose, true, field1, 1, field2, 2, field3, 3, field4, 4, field5, 5.0, field6, 5.0, field7, 7, }]", result.toString());
+        Assert.assertArrayEquals(entityIds, result.toArray());
     }
 }

--- a/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/TopologyCheckAppConfig.java
+++ b/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/TopologyCheckAppConfig.java
@@ -77,14 +77,15 @@ public class TopologyCheckAppConfig implements Serializable {
         this.dataExtractorConfig.numDataFetcherSpout = config.getInt("topology.numDataFetcherSpout");
         this.dataExtractorConfig.numEntityPersistBolt = config.getInt("topology.numEntityPersistBolt");
         this.dataExtractorConfig.numKafkaSinkBolt = config.getInt("topology.numOfKafkaSinkBolt");
-        this.dataExtractorConfig.resolverAPIUrl = config.getString("topology.resolverAPIUrl");
-        String resolveCls = config.getString("topology.rackResolverCls");
-        try {
-            this.dataExtractorConfig.resolverCls = (Class<? extends TopologyRackResolver>) Class.forName(resolveCls);
-        } catch (ClassNotFoundException e) {
-            LOG.warn("{} is not found, will use DefaultTopologyRackResolver instead", resolveCls);
-            this.dataExtractorConfig.resolverCls = DefaultTopologyRackResolver.class;
-            //e.printStackTrace();
+
+        this.dataExtractorConfig.resolverCls = DefaultTopologyRackResolver.class;
+        if (config.hasPath("topology.rackResolverCls")) {
+            String resolveCls = config.getString("topology.rackResolverCls");
+            try {
+                this.dataExtractorConfig.resolverCls = (Class<? extends TopologyRackResolver>) Class.forName(resolveCls);
+            } catch (ClassNotFoundException e) {
+                LOG.warn("{} is not found, will use DefaultTopologyRackResolver instead", resolveCls);
+            }
         }
 
         if (config.hasPath("dataSourceConfig.hbase.enabled") && config.getBoolean("dataSourceConfig.hbase.enabled")) {
@@ -121,7 +122,6 @@ public class TopologyCheckAppConfig implements Serializable {
         public int numKafkaSinkBolt;
         public long fetchDataIntervalInSecs;
         public int parseThreadPoolSize;
-        public String resolverAPIUrl;
         public Class<? extends TopologyRackResolver> resolverCls;
     }
 

--- a/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/resolver/TopologyRackResolver.java
+++ b/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/resolver/TopologyRackResolver.java
@@ -18,7 +18,11 @@
 
 package org.apache.eagle.topology.resolver;
 
+import org.apache.eagle.topology.TopologyCheckAppConfig;
+
 public interface TopologyRackResolver {
+
+    default void prepare(TopologyCheckAppConfig config) {}
 
     /**
      *resolve rack by hostname.

--- a/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/resolver/impl/ClusterNodeAPITopologyRackResolver.java
+++ b/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/resolver/impl/ClusterNodeAPITopologyRackResolver.java
@@ -21,6 +21,7 @@ package org.apache.eagle.topology.resolver.impl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.eagle.app.utils.AppConstants;
 import org.apache.eagle.app.utils.connection.InputStreamUtils;
+import org.apache.eagle.topology.TopologyCheckAppConfig;
 import org.apache.eagle.topology.resolver.TopologyRackResolver;
 import org.apache.eagle.topology.resolver.model.Node;
 import org.slf4j.Logger;
@@ -40,8 +41,9 @@ public class ClusterNodeAPITopologyRackResolver implements TopologyRackResolver 
     private String hostPort = "8041";//TODO configurable
     private static final ObjectMapper OBJ_MAPPER = new ObjectMapper();
 
-    public ClusterNodeAPITopologyRackResolver(String activeApiUrl) {
-        this.activeApiUrl = activeApiUrl;
+    @Override
+    public void prepare(TopologyCheckAppConfig config) {
+        this.activeApiUrl = config.getConfig().getString("topology.resolverAPIUrl");
     }
 
     @Override

--- a/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/resolver/impl/IPMaskTopologyRackResolver.java
+++ b/eagle-topology-check/eagle-topology-app/src/main/java/org/apache/eagle/topology/resolver/impl/IPMaskTopologyRackResolver.java
@@ -49,9 +49,10 @@ public class IPMaskTopologyRackResolver implements TopologyRackResolver {
             InetAddress address = InetAddress.getByName(hostname);
             result = "rack" + (int) (address.getAddress()[rackPos] & 0xff);
         } catch (UnknownHostException e) {
-            //LOG.warn("UnknownHostException: {}", hostname);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("UnknownHostException: {}", hostname);
+            }
         }
         return result;
     }
-
 }

--- a/eagle-topology-check/eagle-topology-app/src/test/java/org/apache/eagle/topology/TestClusterNodeAPITopologyRackResolver.java
+++ b/eagle-topology-check/eagle-topology-app/src/test/java/org/apache/eagle/topology/TestClusterNodeAPITopologyRackResolver.java
@@ -28,7 +28,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
 import java.util.HashMap;
 
 import static org.mockito.Matchers.anyObject;
@@ -41,7 +40,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 public class TestClusterNodeAPITopologyRackResolver {
     private static final String apiUrl = "http://yhd-jqhadoop168.int.yihaodian.com:8088/ws/v1/cluster/nodes";
     private static final TopologyCheckAppConfig config = TopologyCheckAppConfig.newInstance(ConfigFactory.load().withFallback(
-        ConfigFactory.parseMap(new HashMap<String,String>() {{
+        ConfigFactory.parseMap(new HashMap<String, String>() {{
             put("topology.resolverAPIUrl", apiUrl);
         }})));
 

--- a/eagle-topology-check/eagle-topology-app/src/test/java/org/apache/eagle/topology/TestClusterNodeAPITopologyRackResolver.java
+++ b/eagle-topology-check/eagle-topology-app/src/test/java/org/apache/eagle/topology/TestClusterNodeAPITopologyRackResolver.java
@@ -17,6 +17,7 @@
  */
 package org.apache.eagle.topology;
 
+import com.typesafe.config.ConfigFactory;
 import org.apache.eagle.app.utils.connection.InputStreamUtils;
 import org.apache.eagle.topology.resolver.TopologyRackResolver;
 import org.apache.eagle.topology.resolver.impl.ClusterNodeAPITopologyRackResolver;
@@ -28,6 +29,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
+import java.util.HashMap;
 
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
@@ -37,27 +39,31 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(InputStreamUtils.class)
 public class TestClusterNodeAPITopologyRackResolver {
+    private static final String apiUrl = "http://yhd-jqhadoop168.int.yihaodian.com:8088/ws/v1/cluster/nodes";
+    private static final TopologyCheckAppConfig config = TopologyCheckAppConfig.newInstance(ConfigFactory.load().withFallback(
+        ConfigFactory.parseMap(new HashMap<String,String>() {{
+            put("topology.resolverAPIUrl", apiUrl);
+        }})));
+
     @Test
     public void testClusterNodeAPITopologyRackResolver() throws Exception {
         mockStatic(InputStreamUtils.class);
-        String apiUrl = "http://yhd-jqhadoop168.int.yihaodian.com:8088/ws/v1/cluster/nodes";
         String hostname = "hostname";
         mockInputSteam("/nodeinfo.json", apiUrl + "/" + hostname + ":8041");
-
         Class<? extends TopologyRackResolver> resolverCls = (Class<? extends TopologyRackResolver>) Class.forName("org.apache.eagle.topology.resolver.impl.ClusterNodeAPITopologyRackResolver");
         Assert.assertTrue(resolverCls == ClusterNodeAPITopologyRackResolver.class);
-        Constructor ctor = resolverCls.getConstructor(String.class);
-        TopologyRackResolver topologyRackResolver = (TopologyRackResolver) ctor.newInstance(apiUrl);
+        TopologyRackResolver topologyRackResolver = resolverCls.newInstance();
+        topologyRackResolver.prepare(config);
         Assert.assertEquals("/rowb/rack12", topologyRackResolver.resolve(hostname));
     }
 
     @Test
     public void testClusterNodeAPITopologyRackResolver1() throws Exception {
         mockStatic(InputStreamUtils.class);
-        String apiUrl = "http://yhd-jqhadoop168.int.yihaodian.com:8088/ws/v1/cluster/nodes";
         String hostname = "hostname";
         mockInputSteamWithException(apiUrl + "/" + hostname + ":8041");
-        TopologyRackResolver topologyRackResolver = new ClusterNodeAPITopologyRackResolver(apiUrl);
+        TopologyRackResolver topologyRackResolver = new ClusterNodeAPITopologyRackResolver();
+        topologyRackResolver.prepare(config);
         Assert.assertEquals("/default-rack", topologyRackResolver.resolve(hostname));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,8 @@
     </developers>
     <modules>
         <module>eagle-core</module>
-        <!--<module>eagle-webservice</module>-->
         <module>eagle-security</module>
         <module>eagle-external</module>
-        <!--<module>eagle-assembly</module>-->
         <module>eagle-topology-assembly</module>
         <module>eagle-examples</module>
         <module>eagle-gc</module>


### PR DESCRIPTION
* Refactor TopologyCheckAppConfig and TopologyRackResolver
* Fix unit test cases after using `fasterxml-jackson`:
   * `TestGenericEntityServiceResource.java`
   * `TestResourceUnmarshal.java`
* Try to get eagle service port from config by key: service.port no matter STRING or INT.