### PR TITLE
[EAGLE-873] Add job name column to let user search their jobs using that field

### DIFF
--- a/eagle-hadoop-metric/src/main/webapp/app/apps/hadoop_metric/ctrls/backupMasterListCtrl.js
+++ b/eagle-hadoop-metric/src/main/webapp/app/apps/hadoop_metric/ctrls/backupMasterListCtrl.js
@@ -26,7 +26,9 @@
 
 			// Initialization
 			PageConfig.title = "HBASE BackupMasters";
+			$scope.tableScope = {};
 			$scope.site = $wrapState.param.siteId;
+			$scope.searchPathList = [["tags", "hostname"], ["tags", "rack"], ["tags", "site"], ["status"]];
 			$scope.backupMasterList = METRIC.hbaseMaster($scope.site, "standby", 1000);
 		});
 	});

--- a/eagle-hadoop-metric/src/main/webapp/app/apps/hadoop_metric/partials/backupMasterList.html
+++ b/eagle-hadoop-metric/src/main/webapp/app/apps/hadoop_metric/partials/backupMasterList.html
@@ -18,7 +18,7 @@
 <div class="box box-primary">
 	<div class="box-header with-border">
 		<h3 class="box-title">
-			<span ng-show="!regionserverList._done || isSorting" class="fa fa-refresh fa-spin no-animate"></span>
+			<span ng-show="!backupMasterList._done || isSorting" class="fa fa-refresh fa-spin no-animate"></span>
 		</h3>
 	</div>
 	<div class="box-body">

--- a/eagle-jpm/eagle-jpm-web/src/main/webapp/app/apps/jpm/ctrl/listCtrl.js
+++ b/eagle-jpm/eagle-jpm-web/src/main/webapp/app/apps/jpm/ctrl/listCtrl.js
@@ -30,7 +30,7 @@
 			$scope.tableScope = {};
 
 			$scope.site = $wrapState.param.siteId;
-			$scope.searchPathList = [["tags", "jobId"], ["tags", "user"], ["tags", "queue"], ["currentState"]];
+			$scope.searchPathList = [["tags", "jobId"],["tags", "jobName"], ["tags", "user"], ["tags", "queue"], ["currentState"]];
 
 			function getCommonOption(left) {
 				return {
@@ -62,6 +62,7 @@
 				 * @property {[]} jobList
 				 * @property {{}} jobList.tags						unique job key
 				 * @property {string} jobList.tags.jobId			Job Id
+				 * @property {string} jobList.tags.jobName			Job Name
 				 * @property {string} jobList.tags.user				Submit user
 				 * @property {string} jobList.tags.queue			Queue
 				 * @property {string} jobList.currentState			Job state

--- a/eagle-jpm/eagle-jpm-web/src/main/webapp/app/apps/jpm/partials/job/list.html
+++ b/eagle-jpm/eagle-jpm-web/src/main/webapp/app/apps/jpm/partials/job/list.html
@@ -54,6 +54,7 @@
 				<thead>
 					<tr>
 						<th sortpath="tags.jobId">Job ID</th>
+						<th sortpath="tags.jobName">Job Name</th>
 						<th sortpath="currentState">Status</th>
 						<th sortpath="tags.user" width="10">User</th>
 						<th sortpath="tags.queue">Queue</th>
@@ -71,6 +72,7 @@
 						<td>
 							<a ui-sref="jpmDetail({siteId: site, jobId: item.tags.jobId})" target="_blank">{{item.tags.jobId}}</a>
 						</td>
+						<td>{{item.tags.jobName}}</td>
 						<td class="text-center">
 							<span class="label label-sm label-{{getStateClass(item.currentState)}}">
 								{{item.currentState}}


### PR DESCRIPTION
[EAGLE-873] Add job name column to let user search their jobs using that field
- Add jobName column in JPM job list.
- Add jobName to searchList

https://issues.apache.org/jira/browse/EAGLE-873