### PR TITLE
[EAGLE-881] Url of scala-tools repository is no longer valid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1108,21 +1108,5 @@
                 <updatePolicy>never</updatePolicy>
             </releases>
         </repository>
-        <repository>
-            <id>scala-tools.org</id>
-            <name>Scala-Tools Maven2 Repository</name>
-            <url>http://scala-tools.org/repo-releases</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-        </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>scala-tools-maven2-repository</id>
-            <name>Scala-Tools Maven2 Repository</name>
-            <url>http://scala-tools.org/repo-releases</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1074,7 +1074,6 @@
                         <exclude>**/MANIFEST.MF</exclude>
                         <!-- External dependency script -->
                         <exclude>**/resource/serf/etc/ambari.json</exclude>
-
                         <!-- TODO: fix it -->
                         <exclude>**/webapp/**</exclude>
 


### PR DESCRIPTION
Removed the repositories declaration of "Scala-Tools Maven2 Repository" from "eagle-parent" pom file, so that maven can download them from default maven repo.

<!--
{% comment %}
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to you under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
{% endcomment %}
-->