### PR TITLE
[EAGLE-888] Application submitted to Storm is always shown as “HBaseAuditLogApp”

### DIFF
--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationAction.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/service/ApplicationAction.java
@@ -89,13 +89,13 @@ public class ApplicationAction implements Serializable {
 
         if (serverConfig.hasPath(AlertConstants.COORDINATOR)) {
             this.effectiveConfig = ConfigFactory.parseMap(executionConfig)
-                    .withFallback(serverConfig)
                     .withFallback(ConfigFactory.parseMap(metadata.getContext()))
+                    .withFallback(serverConfig)
                     .withFallback(serverConfig.getConfig(AlertConstants.COORDINATOR));
         } else {
             this.effectiveConfig = ConfigFactory.parseMap(executionConfig)
-                    .withFallback(serverConfig)
-                    .withFallback(ConfigFactory.parseMap(metadata.getContext()));
+                    .withFallback(ConfigFactory.parseMap(metadata.getContext()))
+                    .withFallback(serverConfig);
         }
         this.alertMetadataService = alertMetadataService;
     }


### PR DESCRIPTION
Reordered the "withFallBack" function to get user's topology configuration