### PR TITLE
EAGLE-889: Add a restful API for Hadoop running queue to query top N users or jobs

### DIFF
--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/common/HadoopClusterConstants.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/common/HadoopClusterConstants.java
@@ -80,6 +80,7 @@ public class HadoopClusterConstants {
     }
 
     public static final String RUNNING_QUEUE_SERVICE_NAME = "RunningQueueService";
+    public static final String QUEUE_MAPPING_SERVICE_NAME = "QueueMappingService";
 
     // tag constants
     public static final String TAG_PARENT_QUEUE = "parentQueue";

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/crawler/SchedulerInfoParseListener.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/crawler/SchedulerInfoParseListener.java
@@ -161,6 +161,7 @@ public class SchedulerInfoParseListener {
         queueStructureAPIEntity.setTags(_tags);
         queueStructureAPIEntity.setSubQueues(subQueues);
         queueStructureAPIEntity.setAllSubQueues(allSubQueues);
+        queueStructureAPIEntity.setLastUpdateTime(currentTimestamp);
         runningQueueAPIEntities.add(queueStructureAPIEntity);
 
         return allSubQueues;

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/HadoopQueueEntityRepository.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/HadoopQueueEntityRepository.java
@@ -17,13 +17,13 @@
  */
 package org.apache.eagle.hadoop.queue.model;
 
-import org.apache.eagle.hadoop.queue.model.scheduler.ParentQueueAPIEntity;
+import org.apache.eagle.hadoop.queue.model.scheduler.QueueStructureAPIEntity;
 import org.apache.eagle.hadoop.queue.model.scheduler.RunningQueueAPIEntity;
 import org.apache.eagle.log.entity.repo.EntityRepository;
 
 public class HadoopQueueEntityRepository extends EntityRepository {
     public HadoopQueueEntityRepository() {
         this.registerEntity(RunningQueueAPIEntity.class);
-        this.registerEntity(ParentQueueAPIEntity.class);
+        this.registerEntity(QueueStructureAPIEntity.class);
     }
 }

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/HadoopQueueEntityRepository.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/HadoopQueueEntityRepository.java
@@ -17,11 +17,13 @@
  */
 package org.apache.eagle.hadoop.queue.model;
 
+import org.apache.eagle.hadoop.queue.model.scheduler.ParentQueueAPIEntity;
 import org.apache.eagle.hadoop.queue.model.scheduler.RunningQueueAPIEntity;
 import org.apache.eagle.log.entity.repo.EntityRepository;
 
 public class HadoopQueueEntityRepository extends EntityRepository {
     public HadoopQueueEntityRepository() {
         this.registerEntity(RunningQueueAPIEntity.class);
+        this.registerEntity(ParentQueueAPIEntity.class);
     }
 }

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/ParentQueueAPIEntity.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/ParentQueueAPIEntity.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.hadoop.queue.model.scheduler;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.eagle.hadoop.queue.common.HadoopClusterConstants;
+import org.apache.eagle.log.base.taggedlog.TaggedLogAPIEntity;
+import org.apache.eagle.log.entity.meta.*;
+
+import java.util.Map;
+
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@Table("queue_map")
+@ColumnFamily("f")
+@Prefix("queueMap")
+@Service(HadoopClusterConstants.QUEUE_MAPPING_SERVICE_NAME)
+@TimeSeries(false)
+@Partition( {"site"})
+public class ParentQueueAPIEntity extends TaggedLogAPIEntity {
+    @Column("a")
+    Map<String, String> queueMap;
+
+    public Map<String, String> getQueueMap() {
+        return queueMap;
+    }
+
+    public void setQueueMap(Map<String, String> queueMap) {
+        this.queueMap = queueMap;
+        valueChanged("queueMap");
+    }
+
+}

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/QueueStructureAPIEntity.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/QueueStructureAPIEntity.java
@@ -36,6 +36,8 @@ public class QueueStructureAPIEntity extends TaggedLogAPIEntity {
     private List<String> subQueues;
     @Column("b")
     private List<String> allSubQueues;
+    @Column("c")
+    private long lastUpdateTime;
 
     public List<String> getSubQueues() {
         return subQueues;
@@ -53,6 +55,15 @@ public class QueueStructureAPIEntity extends TaggedLogAPIEntity {
     public void setAllSubQueues(List<String> allSubQueues) {
         this.allSubQueues = allSubQueues;
         valueChanged("allSubQueues");
+    }
+
+    public long getLastUpdateTime() {
+        return lastUpdateTime;
+    }
+
+    public void setLastUpdateTime(long lastUpdateTime) {
+        this.lastUpdateTime = lastUpdateTime;
+        valueChanged("lastUpdateTime");
     }
 
 }

--- a/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/QueueStructureAPIEntity.java
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/java/org/apache/eagle/hadoop/queue/model/scheduler/QueueStructureAPIEntity.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.hadoop.queue.model.scheduler;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.apache.eagle.hadoop.queue.common.HadoopClusterConstants;
+import org.apache.eagle.log.base.taggedlog.TaggedLogAPIEntity;
+import org.apache.eagle.log.entity.meta.*;
+
+import java.util.List;
+
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
+@Table("queue_map")
+@ColumnFamily("f")
+@Prefix("queueMap")
+@Service(HadoopClusterConstants.QUEUE_MAPPING_SERVICE_NAME)
+@TimeSeries(false)
+@Partition( {"site"})
+public class QueueStructureAPIEntity extends TaggedLogAPIEntity {
+    @Column("a")
+    private List<String> subQueues;
+    @Column("b")
+    private List<String> allSubQueues;
+
+    public List<String> getSubQueues() {
+        return subQueues;
+    }
+
+    public void setSubQueues(List<String> subQueues) {
+        this.subQueues = subQueues;
+        valueChanged("subQueues");
+    }
+
+    public List<String> getAllSubQueues() {
+        return allSubQueues;
+    }
+
+    public void setAllSubQueues(List<String> allSubQueues) {
+        this.allSubQueues = allSubQueues;
+        valueChanged("allSubQueues");
+    }
+
+}

--- a/eagle-jpm/eagle-hadoop-queue/src/main/resources/META-INF/providers/org.apache.eagle.hadoop.queue.HadoopQueueRunningAppProvider.xml
+++ b/eagle-jpm/eagle-hadoop-queue/src/main/resources/META-INF/providers/org.apache.eagle.hadoop.queue.HadoopQueueRunningAppProvider.xml
@@ -57,7 +57,7 @@
         <property>
             <name>dataSinkConfig.topic</name>
             <displayName>dataSinkConfig.topic</displayName>
-            <value>hadoop_leaf_queue</value>
+            <value>yarn_queue</value>
             <description>topic for kafka data sink</description>
         </property>
         <property>

--- a/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobParser.java
+++ b/eagle-jpm/eagle-jpm-mr-running/src/main/java/org/apache/eagle/jpm/mr/running/parser/MRJobParser.java
@@ -135,6 +135,8 @@ public class MRJobParser implements Runnable {
         JobExecutionAPIEntity jobExecutionAPIEntity = mrJobEntityMap.get(mrJobId);
         jobExecutionAPIEntity.setInternalState(Constants.AppState.FINISHED.toString());
         jobExecutionAPIEntity.setCurrentState(Constants.AppState.RUNNING.toString());
+        // set an estimated job finished time because it's hard the get the specific one
+        jobExecutionAPIEntity.setEndTime(System.currentTimeMillis());
         mrJobConfigs.remove(mrJobId);
         if (mrJobConfigs.size() == 0) {
             this.parserStatus = ParserStatus.APP_FINISHED;

--- a/eagle-jpm/eagle-jpm-service/pom.xml
+++ b/eagle-jpm/eagle-jpm-service/pom.xml
@@ -43,5 +43,10 @@
             <artifactId>eagle-jpm-entity</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
+            <artifactId>eagle-hadoop-queue</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
+++ b/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.service.jpm;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.Map;
+
+@Path("queue")
+public class RunningQueueResource {
+
+    @Path("/{queueName}/users")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Double> getUsersByQueue(@QueryParam("top") int top, @QueryParam("currentTime") long currentTime) {
+        return null;
+    }
+
+    @Path("/{queueName}/jobs")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, Double> getJobsByQueue(@QueryParam("top") int top, @QueryParam("currentTime") long currentTime) {
+        return null;
+    }
+
+
+
+}

--- a/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
+++ b/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
@@ -71,7 +71,7 @@ public class RunningQueueResource {
                     if (userUsage.containsKey(user)) {
                         userUsage.put(user, userUsage.get(user) + job.getAllocatedMB());
                     } else {
-                        userUsage.put(user, 0L);
+                        userUsage.put(user, job.getAllocatedMB());
                     }
                     jobUsage.put(jobId, job.getAllocatedMB());
                 }

--- a/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
+++ b/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
@@ -78,7 +78,7 @@ public class RunningQueueResource {
             }
             result.setJobs(getTopRecords(top, jobUsage));
             result.setUsers(getTopRecords(top, userUsage));
-         } catch (Exception e) {
+        } catch (Exception e) {
             result.setErrMessage(e.getMessage());
         }
         return result;
@@ -86,7 +86,8 @@ public class RunningQueueResource {
 
     private List<JobExecutionAPIEntity> getRunningJobs(String site, long currentTime, String startTime, String endTime) throws Exception {
         GenericEntityServiceResource resource = new GenericEntityServiceResource();
-        String query = String.format("%s[@site=\"%s\" and @startTime<=%s and (@internalState=\"RUNNING\" or @endTime>%s)]{@jobId, @user, @queue, @allocatedMB}", JPA_RUNNING_JOB_EXECUTION_SERVICE_NAME, site, currentTime, currentTime);
+        String query = String.format("%s[@site=\"%s\" and @startTime<=%s and (@internalState=\"RUNNING\" or @endTime>%s)]{@jobId, @user, @queue, @allocatedMB}",
+                JPA_RUNNING_JOB_EXECUTION_SERVICE_NAME, site, currentTime, currentTime);
         GenericServiceAPIResponseEntity<JobExecutionAPIEntity> runningJobResponse = resource.search(query, startTime, endTime, Integer.MAX_VALUE, null, false, false, 0L, 0, false, 0, null, false);
 
         if (!runningJobResponse.isSuccess() || runningJobResponse.getObj() == null) {
@@ -96,7 +97,10 @@ public class RunningQueueResource {
         return runningJobResponse.getObj();
     }
 
-    private List<org.apache.eagle.jpm.mr.historyentity.JobExecutionAPIEntity> getJobs(String site, long currentTime,  String startTime, String endTime) throws Exception{
+    private List<org.apache.eagle.jpm.mr.historyentity.JobExecutionAPIEntity> getJobs(String site,
+                                                                                      long currentTime,
+                                                                                      String startTime,
+                                                                                      String endTime) throws Exception {
         GenericEntityServiceResource resource = new GenericEntityServiceResource();
         String query = String.format("%s[@site=\"%s\" and @startTime<=%s and @endTime>%s]{@jobId}", JPA_JOB_EXECUTION_SERVICE_NAME, site, currentTime, currentTime);
 

--- a/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
+++ b/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResource.java
@@ -140,7 +140,7 @@ public class RunningQueueResource {
         Map<String, Long> newMap = new LinkedHashMap<>();
 
         List<Map.Entry<String,Long>> list = new ArrayList<>(map.entrySet());
-        Collections.sort(list, (o1, o2) -> o1.getValue() >= o2.getValue() ? 1 : -1);
+        Collections.sort(list, (o1, o2) -> o1.getValue() < o2.getValue() ? 1 : -1);
         for (Map.Entry<String, Long> entry : list) {
             if (newMap.size() < top) {
                 newMap.put(entry.getKey(), entry.getValue());

--- a/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResponse.java
+++ b/eagle-jpm/eagle-jpm-service/src/main/java/org/apache/eagle/service/jpm/RunningQueueResponse.java
@@ -15,33 +15,36 @@
  *  limitations under the License.
  */
 
-package org.apache.eagle.hadoop.queue.model.scheduler;
-
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.apache.eagle.hadoop.queue.common.HadoopClusterConstants;
-import org.apache.eagle.log.base.taggedlog.TaggedLogAPIEntity;
-import org.apache.eagle.log.entity.meta.*;
+package org.apache.eagle.service.jpm;
 
 import java.util.Map;
 
-@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
-@Table("queue_map")
-@ColumnFamily("f")
-@Prefix("queueMap")
-@Service(HadoopClusterConstants.QUEUE_MAPPING_SERVICE_NAME)
-@TimeSeries(false)
-@Partition( {"site"})
-public class ParentQueueAPIEntity extends TaggedLogAPIEntity {
-    @Column("a")
-    Map<String, String> queueMap;
+public class RunningQueueResponse {
+    private String errMessage;
+    private Map<String, Long> jobs;
+    private Map<String, Long> users;
 
-    public Map<String, String> getQueueMap() {
-        return queueMap;
+    public String getErrMessage() {
+        return errMessage;
     }
 
-    public void setQueueMap(Map<String, String> queueMap) {
-        this.queueMap = queueMap;
-        valueChanged("queueMap");
+    public void setErrMessage(String errMessage) {
+        this.errMessage = errMessage;
     }
 
+    public Map<String, Long> getJobs() {
+        return jobs;
+    }
+
+    public void setJobs(Map<String, Long> jobs) {
+        this.jobs = jobs;
+    }
+
+    public Map<String, Long> getUsers() {
+        return users;
+    }
+
+    public void setUsers(Map<String, Long> users) {
+        this.users = users;
+    }
 }

--- a/eagle-security/eagle-security-hdfs-auditlog/src/main/resources/META-INF/providers/org.apache.eagle.security.auditlog.HdfsAuditLogAppProvider.xml
+++ b/eagle-security/eagle-security-hdfs-auditlog/src/main/resources/META-INF/providers/org.apache.eagle.security.auditlog.HdfsAuditLogAppProvider.xml
@@ -115,7 +115,7 @@
         <property>
             <name>dataSinkConfig.topic</name>
             <displayName>Kafka Topic for Parsed Data Sink</displayName>
-            <value>hdfs_audit_log_enriched</value>
+            <value>hdfs_audit_event</value>
             <description>topic for kafka data sink</description>
         </property>
         <property>

--- a/eagle-topology-check/eagle-topology-app/src/main/resources/META-INF/providers/org.apache.eagle.topology.TopologyCheckAppProvider.xml
+++ b/eagle-topology-check/eagle-topology-app/src/main/resources/META-INF/providers/org.apache.eagle.topology.TopologyCheckAppProvider.xml
@@ -133,7 +133,7 @@
         <property>
             <name>dataSinkConfig.topic</name>
             <displayName>Topic For Kafka Data Sink</displayName>
-            <value>topology_health_check</value>
+            <value>topology_check</value>
             <description>topic For kafka data sink</description>
         </property>
         <property>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-889

Sample 1: query the top N users/jobs of memory usage under queue1 on site1 at time 1487156721356
http://localhost:9090/rest/queue/memory?top=10&queue=queue1&currentTime=1487156721356&site=site1

Sample 2: query the current queue hierarchy 
http://localhost:9090/rest/entities?query=QueueMappingService[@site=%22sandbox%22]{*}&pageSize=10000

