### PR TITLE
[EAGLE-870] adding required packages into storm-jar

### DIFF
--- a/eagle-topology-assembly/src/assembly/eagle-topology-assembly.xml
+++ b/eagle-topology-assembly/src/assembly/eagle-topology-assembly.xml
@@ -43,8 +43,6 @@
                 <exclude>org.slf4j:slf4j-api</exclude>
                 <exclude>org.slf4j:slf4j-log4j12</exclude>
                 <exclude>io.dropwizard:**</exclude>
-                <exclude>com.sun.jersey:**</exclude>
-                <exclude>com.sun.jersey.contribs:**</exclude>
                 <exclude>org.apache.storm:storm-core</exclude>
             </excludes>
         </dependencySet>


### PR DESCRIPTION
without these required packages, it throws class not found exception, more detail is in the ticket.