### PR TITLE
[MINOR] Fix TestHdfsAuditLogApplication by support await RUNNING

### DIFF
--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/test/ApplicationTestBase.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/test/ApplicationTestBase.java
@@ -43,7 +43,7 @@ public class ApplicationTestBase {
 
     protected void awaitApplicationStop(ApplicationEntity applicationEntity) throws InterruptedException {
         int attempt = 0;
-        while (attempt < 10) {
+        while (attempt < 30) {
             attempt ++;
             if (applicationEntity.getStatus() == ApplicationEntity.Status.STOPPED
                     || applicationEntity.getStatus() == ApplicationEntity.Status.INITIALIZED) {
@@ -53,14 +53,14 @@ public class ApplicationTestBase {
                 Thread.sleep(1000);
             }
         }
-        if (attempt > 10) {
+        if (attempt >= 30) {
             Assert.fail("Failed to wait for application to STOPPED after 10 attempts");
         }
     }
 
     protected void awaitApplicationStatus(ApplicationEntity applicationEntity, ApplicationEntity.Status status) throws InterruptedException {
         int attempt = 0;
-        while (attempt < 10) {
+        while (attempt < 30) {
             attempt ++;
             if (applicationEntity.getStatus() == status) {
                 break;
@@ -69,7 +69,7 @@ public class ApplicationTestBase {
                 Thread.sleep(1000);
             }
         }
-        if (attempt > 10) {
+        if (attempt >= 30) {
             Assert.fail("Failed to wait for application to STOPPED after 10 attempts");
         }
     }

--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/test/ApplicationTestBase.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/test/ApplicationTestBase.java
@@ -57,4 +57,20 @@ public class ApplicationTestBase {
             Assert.fail("Failed to wait for application to STOPPED after 10 attempts");
         }
     }
+
+    protected void awaitApplicationStatus(ApplicationEntity applicationEntity, ApplicationEntity.Status status) throws InterruptedException {
+        int attempt = 0;
+        while (attempt < 10) {
+            attempt ++;
+            if (applicationEntity.getStatus() == status) {
+                break;
+            } else {
+                statusUpdateService.updateApplicationEntityStatus(applicationEntity);
+                Thread.sleep(1000);
+            }
+        }
+        if (attempt > 10) {
+            Assert.fail("Failed to wait for application to STOPPED after 10 attempts");
+        }
+    }
 }

--- a/eagle-security/eagle-security-hdfs-auditlog/src/test/java/org/apache/eagle/security/auditlog/TestHdfsAuditLogApplication.java
+++ b/eagle-security/eagle-security-hdfs-auditlog/src/test/java/org/apache/eagle/security/auditlog/TestHdfsAuditLogApplication.java
@@ -38,8 +38,6 @@ public class TestHdfsAuditLogApplication extends ApplicationTestBase {
     private SiteResource siteResource;
     @Inject
     private ApplicationResource applicationResource;
-    @Inject
-    ApplicationStatusUpdateService statusUpdateService;
 
     @Test
     public void testHdfsAuditLogApplication() throws InterruptedException {

--- a/eagle-security/eagle-security-hdfs-auditlog/src/test/java/org/apache/eagle/security/auditlog/TestHdfsAuditLogApplication.java
+++ b/eagle-security/eagle-security-hdfs-auditlog/src/test/java/org/apache/eagle/security/auditlog/TestHdfsAuditLogApplication.java
@@ -57,7 +57,7 @@ public class TestHdfsAuditLogApplication extends ApplicationTestBase {
         ApplicationEntity applicationEntity = applicationResource.installApplication(installOperation).getData();
         // Start application
         applicationResource.startApplication(new ApplicationOperations.StartOperation(applicationEntity.getUuid()));
-        statusUpdateService.updateApplicationEntityStatus(applicationEntity);
+        awaitApplicationStatus(applicationEntity, ApplicationEntity.Status.RUNNING);
         // Stop application
         applicationResource.stopApplication(new ApplicationOperations.StopOperation(applicationEntity.getUuid()));
         awaitApplicationStop(applicationEntity);


### PR DESCRIPTION
Fix TestHdfsAuditLogApplication by supporting await RUNNING

Resolve Exception: App: HDFS_AUDIT_LOG_MONITOR_APP_TEST_SITE status is STOPPING, uninstall operation is not allowed
 
