### PR TITLE
EAGLE-902 Add JDBC data storage dependency into eagle server module

### DIFF
--- a/eagle-core/eagle-query/eagle-service-base/pom.xml
+++ b/eagle-core/eagle-query/eagle-service-base/pom.xml
@@ -85,6 +85,21 @@
         </dependency>
         <dependency>
             <groupId>org.apache.eagle</groupId>
+            <artifactId>eagle-storage-jdbc</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>servlet-api-2.5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.eagle</groupId>
             <artifactId>eagle-embed-hbase</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/JdbcConstants.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/JdbcConstants.java
@@ -28,7 +28,10 @@ public class JdbcConstants {
     public static final String ROW_KEY_COLUMN_NAME = "uuid";
 
     public static final int DEFAULT_TYPE_FOR_COMPLEX_TYPE = Types.BLOB;
-    public static final int DEFAULT_VARCHAR_SIZE = 30000;
+
+    //MySQL Max Row Size: 21485
+    public static final int DEFAULT_FIELD_VARCHAR_SIZE =1000;
+    public static final int DEFAULT_TAG_VARCHAR_SIZE =254;
 
     // Eagle JDBC Storage Configuration
     public static final String EAGLE_DB_USERNAME = "storage.jdbc.username";

--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntityDefinitionManager.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntityDefinitionManager.java
@@ -150,7 +150,7 @@ public class JdbcEntityDefinitionManager {
     // Initially bind basic java types with SQL types
     //================================================
     static {
-        registerJdbcType(String.class, Types.LONGVARCHAR);
+        registerJdbcType(String.class, Types.VARCHAR);
         registerJdbcType(Integer.class, Types.INTEGER);
         registerJdbcType(Double.class, Types.DOUBLE);
         registerJdbcType(Float.class, Types.FLOAT);

--- a/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntitySchemaManager.java
+++ b/eagle-core/eagle-query/eagle-storage-jdbc/src/main/java/org/apache/eagle/storage/jdbc/schema/JdbcEntitySchemaManager.java
@@ -156,7 +156,7 @@ public class JdbcEntitySchemaManager implements IJdbcEntityDDLManager {
         tagColumn.setTypeCode(Types.VARCHAR);
         tagColumn.setJavaName(tagName);
 //        tagColumn.setScale(1024);
-        tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_VARCHAR_SIZE));
+        tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_FIELD_VARCHAR_SIZE));
         tagColumn.setDefaultValue(null);
         tagColumn.setDescription("eagle entity tag column for "+tagName);
         return tagColumn;
@@ -197,7 +197,7 @@ public class JdbcEntitySchemaManager implements IJdbcEntityDDLManager {
 //            Index index = new UniqueIndex();
             for (String tag : entityDefinition.getInternal().getTags()) {
                 Column tagColumn = createTagColumn(tag);
-                tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_VARCHAR_SIZE));
+                tagColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_TAG_VARCHAR_SIZE));
                 table.addColumn(tagColumn);
 //                IndexColumn indexColumn = new IndexColumn();
 //                indexColumn.setName(tag);
@@ -215,7 +215,7 @@ public class JdbcEntitySchemaManager implements IJdbcEntityDDLManager {
             fieldColumn.setJavaName(entry.getKey());
             Integer typeCode = entityDefinition.getJdbcColumnTypeCodeOrNull(entry.getKey());
             typeCode = typeCode == null? Types.VARCHAR:typeCode;
-            if(typeCode == Types.VARCHAR) fieldColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_VARCHAR_SIZE));
+            if(typeCode == Types.VARCHAR) fieldColumn.setSize(String.valueOf(JdbcConstants.DEFAULT_FIELD_VARCHAR_SIZE));
             fieldColumn.setTypeCode(typeCode);
             fieldColumn.setDescription("eagle field column "+entry.getKey()+":"+entityDefinition.getColumnTypeOrNull(entry.getKey()));
             table.addColumn(fieldColumn);


### PR DESCRIPTION
- add jdbc storage type dependency into eagle-service-base module
- port the fix for mysql table creation failure : [EAGLE-273](https://issues.apache.org/jira/browse/EAGLE-273)