### PR TITLE
[MINOR] Support source_host aside host in metric collector

### DIFF
--- a/eagle-external/hadoop_jmx_collector/metric_collector.py
+++ b/eagle-external/hadoop_jmx_collector/metric_collector.py
@@ -433,6 +433,8 @@ class JmxMetricCollector(MetricCollector):
 
     def jmx_reader(self, source):
         host = source["host"]
+        if source.has_key("source_host"):
+            host=source["source_host"]    
         port=source["port"]
         https=source["https"]
         protocol = "https" if https else "http"


### PR DESCRIPTION
Support `source_host` aside `host` in metric collector configuration for case when requesting host is not the actual host for reason like network settings.