### PR TITLE
[MINOR] Add Authorization into Access-Control-Allow-Headers header

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/resource/SimpleCORSFiler.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/resource/SimpleCORSFiler.java
@@ -47,7 +47,7 @@ public class SimpleCORSFiler implements Filter {
         response.setHeader("Access-Control-Allow-Methods", "HEAD, POST, GET, PUT, OPTIONS, DELETE");
         response.setHeader("Access-Control-Max-Age", "3600");
         response.setHeader("Access-Control-Allow-Headers",
-                "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers");
+                "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Authorization");
         chain.doFilter(request, response);
     }
 


### PR DESCRIPTION
Add `Authorization` into `Access-Control-Allow-Headers` header:

    "Access-Control-Allow-Headers": "Origin, Accept, X-Requested-With, Content-Type, Access-Control-Request-Method, Access-Control-Request-Headers, Authorization"