### PR TITLE
[MINOR] fix system-metric-collector collect disk info bug

### DIFF
--- a/eagle-external/hadoop_jmx_collector/system_metric_collector.py
+++ b/eagle-external/hadoop_jmx_collector/system_metric_collector.py
@@ -296,7 +296,7 @@ class SystemMetricCollector(MetricCollector):
             filtered_items = [items[5], items[6], items[9], items[11]]
             iostat_dict[items[0]] = filtered_items
 
-        disk_output = os.popen("df -k | grep ^/dev").readlines()
+        disk_output = os.popen("df -Pk | grep ^/dev").readlines()
         for item in disk_output:
             items = re.split('\s+', item.strip())
             disks = re.split('^\/dev\/(\w+)\d+$', items[0])


### PR DESCRIPTION
`df -k` result line may be folded into two lines if filesystem is to long , add `P` can avoid this problem