### PR TITLE
EAGLE-971: fix a bug that duplicated queues are generated under a monitored stream

### DIFF
--- a/eagle-assembly/src/main/conf/eagle.conf
+++ b/eagle-assembly/src/main/conf/eagle.conf
@@ -142,12 +142,14 @@ application {
 
 # Coordinator Configuration
 coordinator {
-  policiesPerBolt = 5
-  boltParallelism = 5
+#  boltParallelism = 5
   policyDefaultParallelism = 5
   boltLoadUpbound = 0.8
   topologyLoadUpbound = 0.8
   numOfAlertBoltsPerTopology = 5
+  policiesPerBolt = 10
+  streamsPerBolt = 10
+  reuseBoltInStreams = true
   zkConfig {
     zkQuorum = "server.eagle.apache.org:2181"
     zkRoot = "/alert"

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/TopologyMgmtService.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-coordinator/src/main/java/org/apache/eagle/alert/coordinator/TopologyMgmtService.java
@@ -56,7 +56,7 @@ public class TopologyMgmtService {
 
     public TopologyMgmtService() {
         Config config = ConfigFactory.load().getConfig(CONFIG_ITEM_COORDINATOR);
-        boltParallelism = config.getInt(CoordinatorConstants.BOLT_PARALLELISM);
+        //boltParallelism = config.getInt(CoordinatorConstants.BOLT_PARALLELISM);
         numberOfBoltsPerTopology = config.getInt(NUM_OF_ALERT_BOLTS_PER_TOPOLOGY);
     }
 

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/spout/CorrelationSpout.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-engine/src/main/java/org/apache/eagle/alert/engine/spout/CorrelationSpout.java
@@ -168,7 +168,12 @@ public class CorrelationSpout extends BaseRichSpout implements SpoutSpecListener
     @Override
     public void nextTuple() {
         for (KafkaSpoutWrapper wrapper : kafkaSpoutList.values()) {
-            wrapper.nextTuple();
+            try {
+                wrapper.nextTuple();
+            } catch (Exception e) {
+                LOG.error("unexpected exception is caught: {}", e.getMessage(), e);
+            }
+
         }
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-971

New policies for alert spec generation
1. each alert bolt has no more than 'coordinator.policiesPerBolt' policies.
2. each alert bolt has no more than 'coordinator.streamsPerBolt' queues if 'reuseBoltInStreams' is true
3. NO queues on one alert bolt have the same StreamGroup.
