### PR TITLE
[EAGLE-981] GC overhead limit exceeded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,3 @@ script:
   - mvn clean test -B
 jdk:
   - oraclejdk8
-cache:
-  directories:
-      - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,15 @@ language: java
 jdk:
   - oraclejdk8
 
-before_install: echo "MAVEN_OPTS='-Xmx2048m -Xms1024m -XX:MaxPermSize=512m'" > ~/.mavenrc
+before_install: sudo echo "MAVEN_OPTS='-Xmx2048m -Xms1024m'" > ~/.mavenrc
 
-script:
-  - mvn clean test
+script: mvn clean test
 
 env:
   global:
-    - MAVEN_OPTS: "-Xmx1024m -Xms512m -XX:MaxPermSize=256m"
+    - MAVEN_OPTS: "-Xmx2048m -Xms1024m"
 
-sudo: false
+sudo: required
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,21 @@
 # limitations under the License.
 
 language: java
-before_install:
-  - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=512m'" > ~/.mavenrc
-script:
-  - mvn clean test -B
+
 jdk:
   - oraclejdk8
+
+before_install: echo "MAVEN_OPTS='-Xmx2048m -Xms1024m -XX:MaxPermSize=512m'" > ~/.mavenrc
+
+script:
+  - mvn clean test
+
+env:
+  global:
+    - MAVEN_OPTS: "-Xmx1024m -Xms512m -XX:MaxPermSize=256m"
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 language: java
-script: mvn clean test
+script: mvn clean test -B
 jdk:
   - oraclejdk8
+cache:
+  directories:
+      - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@
 # limitations under the License.
 
 language: java
-script: mvn clean test -B
+before_script:
+  - export MAVEN_SKIP_RC=true
+script:
+  - export MAVEN_OPTS="-Xmx1024M -Xss128M -XX:MaxPermSize=512M -XX:+CMSClassUnloadingEnabled"
+  - mvn clean test -B
 jdk:
   - oraclejdk8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ language: java
 before_script:
   - export MAVEN_SKIP_RC=true
 script:
-  - export MAVEN_OPTS="-Xmx1024M -Xss128M -XX:MaxPermSize=512M -XX:+CMSClassUnloadingEnabled"
-  - mvn clean test -B
+  - export MAVEN_OPTS="-Xmx1024M"
+  - mvn clean test
 jdk:
   - oraclejdk8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,9 @@
 
 language: java
 before_script:
-  - export MAVEN_SKIP_RC=true
+  - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=512m'" > ~/.mavenrc
 script:
-  - export MAVEN_OPTS="-Xmx1024M"
-  - mvn clean test
+  - mvn clean test -B
 jdk:
   - oraclejdk8
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 language: java
-before_script:
+before_install:
   - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=512m'" > ~/.mavenrc
 script:
   - mvn clean test -B


### PR DESCRIPTION
Travis throw `GC overhead limit exceeded` exception because the default `JVM` option of maven limit the resource of Travis.

![gc_overhead.png](https://issues.apache.org/jira/secure/attachment/12861189/gc_overhead.png)

https://issues.apache.org/jira/browse/EAGLE-981