### PR TITLE
[EAGLE-982] The log length has exceeded the limit of 4 MB in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,20 @@
 # limitations under the License.
 
 language: java
-script: mvn clean test
+
 jdk:
   - oraclejdk8
+
+before_install: sudo echo "MAVEN_OPTS='-Xmx2048m -Xms1024m -Dorg.slf4j.simpleLogger.defaultLogLevel=error'" > ~/.mavenrc
+
+script: mvn clean test
+
+env:
+  global:
+    - MAVEN_OPTS: "-Xmx2048m -Xms1024m -Dorg.slf4j.simpleLogger.defaultLogLevel=error"
+
+sudo: required
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -1119,7 +1119,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire.version}</version>
                     <configuration>
-                        <argLine>-XX:-UseGCOverheadLimit</argLine>
+                        <argLine>-Xmx2048m -Xms1024m -XX:MaxPermSize=512m -XX:-UseGCOverheadLimit</argLine>
                         <forkMode>always</forkMode>
                     </configuration>
                     <dependencies>


### PR DESCRIPTION
Maven throw too many warnings for checking `Code Style` in `Travis`. Should we disable it for a while until we fix those `Code Style` issues?
```
The log length has exceeded the limit of 4 MB (this usually means that the test suite is raising the same exception over and over).
The job has been terminated
```

(https://issues.apache.org/jira/browse/EAGLE-982)