### PR TITLE
EAGLE-987 widget only support in element name to avoid data-widget hit

### DIFF
--- a/eagle-server/src/main/webapp/app/dev/partials/home.html
+++ b/eagle-server/src/main/webapp/app/dev/partials/home.html
@@ -36,7 +36,7 @@
 	<h3>Widgets</h3>
 	<div class="row flex">
 		<div class="col-sm-6 col-md-4 col-lg-3" ng-repeat="widget in Widget.list track by $index">
-			<div widget="widget"></div>
+			<widget widget="widget"></widget>
 		</div>
 	</div>
 </div>

--- a/eagle-server/src/main/webapp/app/dev/partials/site/home.html
+++ b/eagle-server/src/main/webapp/app/dev/partials/site/home.html
@@ -18,7 +18,7 @@
 
 <div class="row flex">
 	<div class="col-sm-6 col-md-4 col-lg-3" ng-repeat="widget in Widget.list track by $index">
-		<div widget="widget"></div>
+		<widget widget="widget"></widget>
 	</div>
 
 	<div class="col-sm-6 col-md-4 col-lg-3" ng-if="Widget.list.length === 0">

--- a/eagle-server/src/main/webapp/app/dev/public/js/components/widget.js
+++ b/eagle-server/src/main/webapp/app/dev/public/js/components/widget.js
@@ -23,7 +23,7 @@
 
 	eagleComponents.directive('widget', function($compile, Site) {
 		return {
-			restrict: 'AE',
+			restrict: 'E',
 			priority: 1001,
 
 			controller: function($scope, $element, $attrs) {


### PR DESCRIPTION
In jpm page. site mapping to the wrong instance. Check its caused by widget directive mapping the data-widget which is used by adminLTE