### PR TITLE
[EAGLE-1009] Fix `return` inside `finally` block may result in losing exception

### DIFF
--- a/eagle-jpm/eagle-jpm-analyzer/src/main/java/org/apache/eagle/jpm/analyzer/util/Utils.java
+++ b/eagle-jpm/eagle-jpm-analyzer/src/main/java/org/apache/eagle/jpm/analyzer/util/Utils.java
@@ -26,7 +26,6 @@ import org.apache.eagle.jpm.util.resourcefetch.connection.InputStreamUtils;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.type.TypeReference;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,55 +45,59 @@ public class Utils {
     public static List<JobMetaEntity> getJobMeta(Config config, String siteId, String jobDefId) {
         List<JobMetaEntity> result = new ArrayList<>();
         String url = "http://"
-                + config.getString(Constants.HOST_PATH)
-                + ":"
-                + config.getInt(Constants.PORT_PATH)
-                + config.getString(Constants.CONTEXT_PATH)
-                + Constants.ANALYZER_PATH
-                + Constants.JOB_META_ROOT_PATH
-                + "/"
-                + siteId
-                + "/"
-                + URLEncoder.encode(jobDefId);
+            + config.getString(Constants.HOST_PATH)
+            + ":"
+            + config.getInt(Constants.PORT_PATH)
+            + config.getString(Constants.CONTEXT_PATH)
+            + Constants.ANALYZER_PATH
+            + Constants.JOB_META_ROOT_PATH
+            + "/"
+            + siteId
+            + "/"
+            + URLEncoder.encode(jobDefId);
 
         InputStream is = null;
         try {
             is = InputStreamUtils.getInputStream(url, null, org.apache.eagle.jpm.util.Constants.CompressionType.NONE);
             LOG.info("get job meta from {}", url);
-            result = ((RESTResponse<List<JobMetaEntity>>)OBJ_MAPPER.readValue(is, new TypeReference<RESTResponse<List<JobMetaEntity>>>(){})).getData();
+            result = ((RESTResponse<List<JobMetaEntity>>) OBJ_MAPPER.readValue(is,
+                new TypeReference<RESTResponse<List<JobMetaEntity>>>() {
+                })).getData();
         } catch (Exception e) {
             LOG.warn("failed to get job meta from {}", url, e);
         } finally {
             org.apache.eagle.jpm.util.Utils.closeInputStream(is);
-            return result;
         }
+        return result;
     }
 
     public static List<UserEmailEntity> getUserMail(Config config, String siteId, String userId) {
         List<UserEmailEntity> result = new ArrayList<>();
         String url = "http://"
-                + config.getString(Constants.HOST_PATH)
-                + ":"
-                + config.getInt(Constants.PORT_PATH)
-                + config.getString(Constants.CONTEXT_PATH)
-                + Constants.ANALYZER_PATH
-                + Constants.USER_META_ROOT_PATH
-                + "/"
-                + siteId
-                + "/"
-                + URLEncoder.encode(userId);
+            + config.getString(Constants.HOST_PATH)
+            + ":"
+            + config.getInt(Constants.PORT_PATH)
+            + config.getString(Constants.CONTEXT_PATH)
+            + Constants.ANALYZER_PATH
+            + Constants.USER_META_ROOT_PATH
+            + "/"
+            + siteId
+            + "/"
+            + URLEncoder.encode(userId);
 
         InputStream is = null;
         try {
             is = InputStreamUtils.getInputStream(url, null, org.apache.eagle.jpm.util.Constants.CompressionType.NONE);
             LOG.info("get user meta from {}", url);
-            result = ((RESTResponse<List<UserEmailEntity>>)OBJ_MAPPER.readValue(is, new TypeReference<RESTResponse<List<UserEmailEntity>>>(){})).getData();
+            result = ((RESTResponse<List<UserEmailEntity>>) OBJ_MAPPER.readValue(is,
+                new TypeReference<RESTResponse<List<UserEmailEntity>>>() {
+                })).getData();
         } catch (Exception e) {
             LOG.warn("failed to get user meta from {}", url, e);
         } finally {
             org.apache.eagle.jpm.util.Utils.closeInputStream(is);
-            return result;
         }
+        return result;
     }
 
     public static <K, V extends Comparable<? super V>> List<Map.Entry<K, V>> sortByValue(Map<K, V> map) {

--- a/eagle-security/eagle-security-common/src/main/java/org/apache/eagle/security/hdfs/MAPRFSAuditLogParser.java
+++ b/eagle-security/eagle-security-common/src/main/java/org/apache/eagle/security/hdfs/MAPRFSAuditLogParser.java
@@ -22,19 +22,16 @@ import org.codehaus.jettison.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.text.ParseException;
-
-
 public final class MAPRFSAuditLogParser {
     private final static Logger LOG = LoggerFactory.getLogger(MAPRFSAuditLogParser.class);
 
-    public MAPRFSAuditLogParser(){
+    public MAPRFSAuditLogParser() {
     }
 
     public MAPRFSAuditLogObject parse(String log) throws JSONException {
         JSONObject jsonObject = new JSONObject(log);
         MAPRFSAuditLogObject entity = new MAPRFSAuditLogObject();
-        try{
+        try {
             String timestamp = jsonObject.getJSONObject("timestamp").getString("$date");
             String cmd = jsonObject.getString("operation");
             String user = jsonObject.getString("uid");
@@ -43,15 +40,15 @@ public final class MAPRFSAuditLogParser {
             String volumeID = jsonObject.getString("volumeId");
             String src;
             String dst;
-            if(jsonObject.has("srcFid")){
+            if (jsonObject.has("srcFid")) {
                 src = jsonObject.getString("srcFid");
-            }else{
+            } else {
                 src = "null";
             }
 
-            if(jsonObject.has("dstFid")){
+            if (jsonObject.has("dstFid")) {
                 dst = jsonObject.getString("dstFid");
-            }else{
+            } else {
                 dst = "null";
             }
             entity.user = user;
@@ -62,10 +59,9 @@ public final class MAPRFSAuditLogParser {
             entity.status = status;
             entity.volume = volumeID;
             entity.timestamp = DateTimeUtil.maprhumanDateToMilliseconds(timestamp);
-        } catch (Exception e){
+        } catch (Exception e) {
             LOG.error("Failed to parse mapr audit log message", e);
-        } finally {
-            return entity;
         }
+        return entity;
     }
 }


### PR DESCRIPTION
`return` inside `finally` block will result in losing exception:

* If the finally block completes abruptly for reason S, then the try statement completes abruptly for reason S (and the throw of value V is discarded and forgotten).
* If the finally block completes abruptly for reason S, then the try statement completes abruptly for reason S (and reason R is discarded).

reference:
http://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.20.2
https://issues.apache.org/jira/secure/attachment/12863778/FinallyTest.java

(https://issues.apache.org/jira/browse/EAGLE-1009)