### PR TITLE
EAGLE-1015: add an interface to add storm configuration in an application

### DIFF
--- a/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/impl/StormExecutionRuntime.java
+++ b/eagle-core/eagle-app/eagle-app-base/src/main/java/org/apache/eagle/app/environment/impl/StormExecutionRuntime.java
@@ -121,7 +121,7 @@ public class StormExecutionRuntime implements ExecutionRuntime<StormEnvironment,
 
         if (config.hasPath(APP_STORM_CONF_PATH_DEFAULT)) {
             com.typesafe.config.Config appStormConf = config.getConfig(APP_STORM_CONF_PATH_DEFAULT);
-            for(Map.Entry<String, ConfigValue> entry: appStormConf.entrySet()) {
+            for (Map.Entry<String, ConfigValue> entry: appStormConf.entrySet()) {
                 if (NumberUtils.isNumber(entry.getValue().unwrapped().toString())) {
                     conf.put(entry.getKey(), appStormConf.getNumber(entry.getKey()));
                 } else {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-1015

Support to add storm config value of type number or string in an application. However, to make storm overrides these custom values,  one rule is the configuration must start with 'application.storm.'. For example: 

`application.storm.workers` to override `workers`
`application.storm.nimbus.host` to override `nimbus.host`
