### PR TITLE
Mysql table eagle_metric_eagle_metric_schema is having issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,13 @@
             <organization>Apache Software Foundation</organization>
             <organizationUrl>https://eagle.apache.org</organizationUrl>
         </developer>
+        <developer>
+            <id>jaysen</id>
+            <name>Jayesh Senjaliya</name>
+            <email>jaysen@apache.org</email>
+            <organization>Apache Software Foundation</organization>
+            <organizationUrl>https://eagle.apache.org</organizationUrl>
+        </developer>
     </developers>
     <modules>
         <module>eagle-core</module>


### PR DESCRIPTION
Hi,
eagle_metric_eagle_metric_schema is having a column_name as "group" which is a reserved keyword. I am getting an error as mysql syntax error near group when i am trying to run the apache eagle application for hadoop_metric_monitor. Initially i was getting error even in creating this table with group keyword as column but i resolved it using `group` .Now it is trying to write to some of the table which is having group as a cloumn_name. That's why it is throwing error. Can somebody help me out.

_______
Thanks
Vikash