### PR TITLE
[EAGLE-1017] New further: support for query alert of a specific machine.

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert-app/src/main/java/org/apache/eagle/alert/app/AlertEagleStorePlugin.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert-app/src/main/java/org/apache/eagle/alert/app/AlertEagleStorePlugin.java
@@ -83,6 +83,16 @@ public class AlertEagleStorePlugin extends AbstractPublishPlugin implements Aler
         tags.put(ALERT_ID_KEY, event.getAlertId());
         tags.put(ALERT_CATEGORY, event.getCategory());
         tags.put(ALERT_SEVERITY, event.getSeverity().toString());
+
+        String host = event.getDataMap().getOrDefault("host", "null").toString();
+        String hostname = event.getDataMap().getOrDefault("hostname", "null").toString();
+
+        if (host != "null") {
+            tags.put(ALERT_HOST, host);
+        } else {
+            tags.put(ALERT_HOST, hostname);
+        }
+
         if (event.getContext() != null && !event.getContext().isEmpty()) {
             tags.put(SITE_ID_KEY, event.getContext().get(SITE_ID_KEY).toString());
             alertEvent.setPolicyValue(event.getContext().get(POLICY_VALUE_KEY).toString());

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/model/AlertPublishEvent.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/model/AlertPublishEvent.java
@@ -48,6 +48,7 @@ public class AlertPublishEvent {
     public static final String POLICY_VALUE_KEY = "policyValue";
     public static final String ALERT_CATEGORY = "category";
     public static final String ALERT_SEVERITY = "severity";
+    public static final String ALERT_HOST = "host";
 
     public String getAlertId() {
         return alertId;


### PR DESCRIPTION
New further: support for query alert of a specific machine.

modified:  
- eagle-core/eagle-alert-parent/eagle-alert-app/src/main/java/org/apache/eagle/alert/app/AlertEagleStorePlugin.java
- eagle-core/eagle-alert-parent/eagle-alert/alert-common/src/main/java/org/apache/eagle/alert/engine/model/AlertPublishEvent.java

Involved modules:
eagle-core

The jira ticket link is:
https://issues.apache.org/jira/browse/EAGLE-1017