### PR TITLE
EAGLE-1022: Fix runtime exception when parsing spark.yarn.executor.memoryOverhead

### DIFF
--- a/eagle-jpm/eagle-jpm-spark-history/src/main/java/org/apache/eagle/jpm/spark/history/crawl/JHFSparkEventReader.java
+++ b/eagle-jpm/eagle-jpm-spark-history/src/main/java/org/apache/eagle/jpm/spark/history/crawl/JHFSparkEventReader.java
@@ -487,8 +487,9 @@ public class JHFSparkEventReader {
         long result = 0L;
         String fieldValue = config.getConfig().get(fieldName);
         if (fieldValue != null) {
-            result = Utils.parseMemory(fieldValue + "m");
-            if (result == 0L) {
+            try {
+                result = Utils.parseMemory(fieldValue + "m");
+            } catch (Exception e) {
                 result = Utils.parseMemory(fieldValue);
             }
         }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-1022