### PR TITLE
EAGLE-1044: Support policy Import using a policy prototype

### DIFF
--- a/eagle-assembly/src/main/doc/metadata-ddl.sql
+++ b/eagle-assembly/src/main/doc/metadata-ddl.sql
@@ -57,6 +57,15 @@ CREATE TABLE IF NOT EXISTS `dashboards` (
   UNIQUE INDEX `name_UNIQUE` (`name` ASC))
 COMMENT = 'eagle dashboard metadata';
 
+CREATE TABLE IF NOT EXISTS `policyProto` (
+  `uuid` VARCHAR(50) NOT NULL,
+  `policyProto` longtext NOT NULL,
+  `alertPublisherIds` VARCHAR(500) NULL,
+  `modifiedtime` BIGINT(20) NOT NULL,
+  `createdtime` BIGINT(20) NOT NULL,
+  PRIMARY KEY (`uuid`))
+COMMENT = 'eagle policy prototype metadata';
+
 -- eagle security module metadata
 
 CREATE TABLE IF NOT EXISTS hdfs_sensitivity_entity (

--- a/eagle-assembly/src/main/doc/metadata-ddl.sql
+++ b/eagle-assembly/src/main/doc/metadata-ddl.sql
@@ -57,13 +57,15 @@ CREATE TABLE IF NOT EXISTS `dashboards` (
   UNIQUE INDEX `name_UNIQUE` (`name` ASC))
 COMMENT = 'eagle dashboard metadata';
 
-CREATE TABLE IF NOT EXISTS `policyProto` (
+CREATE TABLE IF NOT EXISTS `policy_prototype` (
   `uuid` VARCHAR(50) NOT NULL,
-  `policyProto` longtext NOT NULL,
+  `name` VARCHAR(200) NOT NULL,
+  `definition` longtext NOT NULL,
   `alertPublisherIds` VARCHAR(500) NULL,
   `modifiedtime` BIGINT(20) NOT NULL,
   `createdtime` BIGINT(20) NOT NULL,
-  PRIMARY KEY (`uuid`))
+  PRIMARY KEY (`uuid`),
+  UNIQUE INDEX `policy_proto_UNIQUE` (`name` ASC))
 COMMENT = 'eagle policy prototype metadata';
 
 -- eagle security module metadata

--- a/eagle-core/eagle-metadata/eagle-metadata-base/pom.xml
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.eagle</groupId>
-            <artifactId>alert-metadata</artifactId>
+            <artifactId>alert-metadata-service</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/PolicyEntity.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/PolicyEntity.java
@@ -27,15 +27,24 @@ import java.util.*;
 
 public class PolicyEntity extends PersistenceEntity {
     @Length(min = 1, max = 50, message = "length should between 1 and 50")
-    private PolicyDefinition policyProto;
+    private String name;
+    private PolicyDefinition definition;
     private List<String> alertPublishmentIds = new ArrayList<>();
 
-    public PolicyDefinition getPolicyProto() {
-        return policyProto;
+    public String getName() {
+        return name;
     }
 
-    public void setPolicyProto(PolicyDefinition policyProto) {
-        this.policyProto = policyProto;
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public PolicyDefinition getDefinition() {
+        return definition;
+    }
+
+    public void setDefinition(PolicyDefinition definition) {
+        this.definition = definition;
     }
 
     public List<String> getAlertPublishmentIds() {
@@ -49,7 +58,8 @@ public class PolicyEntity extends PersistenceEntity {
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-                .append(policyProto)
+                .append(name)
+                .append(definition)
                 .append(alertPublishmentIds)
                 .build();
     }
@@ -66,13 +76,14 @@ public class PolicyEntity extends PersistenceEntity {
 
         PolicyEntity another = (PolicyEntity) that;
 
-        return Objects.equals(another.policyProto, this.policyProto)
+        return Objects.equals(another.name, this.name)
+                && Objects.equals(another.definition, this.definition)
                 && CollectionUtils.isEqualCollection(another.getAlertPublishmentIds(), alertPublishmentIds);
     }
 
     @Override
     public String toString() {
-        return String.format("{name=\"%s\",definition=%s}", this.getPolicyProto().getName(), this.getPolicyProto() == null ? "null" : this.getPolicyProto().getDefinition().toString());
+        return String.format("{name=\"%s\",definition=%s}", this.name, this.getDefinition() == null ? "null" : this.getDefinition().getDefinition().toString());
     }
 
 }

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/PolicyEntity.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/model/PolicyEntity.java
@@ -1,0 +1,78 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.model;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.metadata.persistence.PersistenceEntity;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.*;
+
+public class PolicyEntity extends PersistenceEntity {
+    @Length(min = 1, max = 50, message = "length should between 1 and 50")
+    private PolicyDefinition policyProto;
+    private List<String> alertPublishmentIds = new ArrayList<>();
+
+    public PolicyDefinition getPolicyProto() {
+        return policyProto;
+    }
+
+    public void setPolicyProto(PolicyDefinition policyProto) {
+        this.policyProto = policyProto;
+    }
+
+    public List<String> getAlertPublishmentIds() {
+        return alertPublishmentIds;
+    }
+
+    public void setAlertPublishmentIds(List<String> alertPublishmentIds) {
+        this.alertPublishmentIds = alertPublishmentIds;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+                .append(policyProto)
+                .append(alertPublishmentIds)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+        if (that == this) {
+            return true;
+        }
+
+        if (!(that instanceof PolicyEntity)) {
+            return false;
+        }
+
+        PolicyEntity another = (PolicyEntity) that;
+
+        return Objects.equals(another.policyProto, this.policyProto)
+                && CollectionUtils.isEqualCollection(another.getAlertPublishmentIds(), alertPublishmentIds);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("{name=\"%s\",definition=%s}", this.getPolicyProto().getName(), this.getPolicyProto() == null ? "null" : this.getPolicyProto().getDefinition().toString());
+    }
+
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/resource/PolicyResource.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/resource/PolicyResource.java
@@ -1,0 +1,140 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.resource;
+
+import com.google.common.base.Preconditions;
+import com.google.inject.Inject;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.alert.engine.interpreter.PolicyValidationResult;
+import org.apache.eagle.alert.metadata.resource.OpResult;
+import org.apache.eagle.common.rest.RESTResponse;
+import org.apache.eagle.metadata.model.PolicyEntity;
+import org.apache.eagle.metadata.service.PolicyEntityService;
+import org.apache.eagle.metadata.utils.PolicyIdConversions;
+import org.apache.eagle.metadata.utils.StreamIdConversions;
+import org.apache.eagle.service.metadata.resource.MetadataResource;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+@Path("/policyProto")
+public class PolicyResource {
+    private final PolicyEntityService policyEntityService;
+    private final MetadataResource metadataResource;
+
+    @Inject
+    public PolicyResource(PolicyEntityService policyEntityService, MetadataResource metadataResource) {
+        this.policyEntityService = policyEntityService;
+        this.metadataResource = metadataResource;
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public RESTResponse<Collection<PolicyEntity>> getAllPolicyProto() {
+        return RESTResponse.async(policyEntityService::getAllPolicyProto).get();
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RESTResponse<PolicyEntity> createOrUpdatePolicyProto(PolicyEntity policyProto) {
+        return RESTResponse.async(() -> policyEntityService.createOrUpdatePolicyProto(policyProto)).get();
+    }
+
+    @POST
+    @Path("saveAsProto")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RESTResponse<PolicyEntity> saveAsPolicyProto(PolicyEntity policyEntity) {
+        Preconditions.checkNotNull(policyEntity, "policyDefinition should not be null");
+        PolicyDefinition policyDefinition = policyEntity.getPolicyProto();
+        List<String> inputStreamType = new ArrayList<>();
+        String newDefinition = policyDefinition.getDefinition().getValue();
+        for (String inputStream : policyDefinition.getInputStreams()) {
+            String streamDef = StreamIdConversions.parseStreamTypeId(policyDefinition.getSiteId(), inputStream);
+            inputStreamType.add(streamDef);
+            newDefinition = newDefinition.replaceAll(inputStream, streamDef);
+        }
+        policyDefinition.setInputStreams(inputStreamType);
+        policyDefinition.getDefinition().setValue(newDefinition);
+        policyDefinition.setName(PolicyIdConversions.parsePolicyId(policyDefinition.getSiteId(), policyDefinition.getName()));
+        policyDefinition.setSiteId(null);
+
+        policyEntity.setPolicyProto(policyDefinition);
+        return createOrUpdatePolicyProto(policyEntity);
+    }
+
+    @POST
+    @Path("loadToSite/{site}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RESTResponse<List<PolicyDefinition>> loadPolicyDefinition(List<PolicyEntity> policyProtoList, @PathParam("site") String site) {
+        return RESTResponse.async(() -> importPolicyDefinition(policyProtoList, site)).get();
+
+    }
+
+    @DELETE
+    @Path("/{uuid}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public RESTResponse<Boolean> deletePolicyProto(@PathParam("uuid") String uuid) {
+        return RESTResponse.async(() -> policyEntityService.deletePolicyProtoByUUID(uuid)).get();
+    }
+
+
+    private List<PolicyDefinition> importPolicyDefinition(List<PolicyEntity> policyProtoList, String site) {
+        Preconditions.checkNotNull(site, "site should not be null");
+        if (policyProtoList == null || policyProtoList.isEmpty()) {
+            throw new IllegalArgumentException("policy prototype list is empty or null");
+        }
+        List<PolicyDefinition> policies = new ArrayList<>();
+        for (PolicyEntity policyProto : policyProtoList) {
+            PolicyDefinition policyDefinition = policyProto.getPolicyProto();
+            List<String> inputStreams = new ArrayList<>();
+            String newDefinition = policyDefinition.getDefinition().getValue();
+            for (String inputStreamType : policyDefinition.getInputStreams()) {
+                String streamId = StreamIdConversions.formatSiteStreamId(site, inputStreamType);
+                inputStreams.add(streamId);
+                newDefinition = newDefinition.replaceAll(inputStreamType, streamId);
+            }
+            policyDefinition.setInputStreams(inputStreams);
+            policyDefinition.getDefinition().setValue(newDefinition);
+            policyDefinition.setSiteId(site);
+            policyDefinition.setName(PolicyIdConversions.generateUniquePolicyId(site, policyProto.getPolicyProto().getName()));
+            PolicyValidationResult validationResult = metadataResource.validatePolicy(policyDefinition);
+            if (!validationResult.isSuccess() || validationResult.getException() != null) {
+                throw new IllegalArgumentException(validationResult.getException());
+            }
+            OpResult result = metadataResource.addPolicy(policyDefinition);
+            if (result.code != 200) {
+                throw new IllegalArgumentException("fail to create policy: " + result.message);
+            }
+            if (policyProto.getAlertPublishmentIds() != null && !policyProto.getAlertPublishmentIds().isEmpty()) {
+                result = metadataResource.addPublishmentsToPolicy(policyDefinition.getName(), policyProto.getAlertPublishmentIds());
+                if (result.code != 200) {
+                    throw new IllegalArgumentException("fail to create policy publisherments: " + result.message);
+                }
+            }
+            policies.add(policyDefinition);
+        }
+        return policies;
+    }
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/resource/PolicyResource.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/resource/PolicyResource.java
@@ -90,7 +90,7 @@ public class PolicyResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public RESTResponse<List<PolicyDefinition>> loadPolicyDefinition(List<PolicyEntity> policyProtoList, @PathParam("site") String site) {
-        return RESTResponse.async(() -> importPolicyDefinition(policyProtoList, site)).get();
+        return RESTResponse.async(() -> exportPolicyDefinition(policyProtoList, site)).get();
     }
 
     @DELETE
@@ -101,7 +101,7 @@ public class PolicyResource {
         return RESTResponse.async(() -> policyEntityService.deletePolicyProtoByUUID(uuid)).get();
     }
 
-    private List<PolicyDefinition> importPolicyDefinition(List<PolicyEntity> policyProtoList, String site) {
+    private List<PolicyDefinition> exportPolicyDefinition(List<PolicyEntity> policyProtoList, String site) {
         Preconditions.checkNotNull(site, "site should not be null");
         if (policyProtoList == null || policyProtoList.isEmpty()) {
             throw new IllegalArgumentException("policy prototype list is empty or null");

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/PolicyEntityService.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/PolicyEntityService.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.service;
+
+import com.google.common.base.Preconditions;
+import org.apache.eagle.metadata.model.PolicyEntity;
+import org.apache.eagle.metadata.persistence.PersistenceService;
+
+import java.util.Collection;
+
+
+public interface PolicyEntityService {
+
+    Collection<PolicyEntity> getAllPolicyProto();
+
+    PolicyEntity getPolicyProtoByUUID(String uuid);
+
+    boolean deletePolicyProtoByUUID(String uuid);
+
+    default PolicyEntity createOrUpdatePolicyProto(PolicyEntity policyProto) {
+        Preconditions.checkNotNull(policyProto, "DashboardEntity should not be null");
+        if (policyProto.getUuid() == null) {
+            return create(policyProto);
+        } else {
+            return update(policyProto);
+        }
+    }
+
+    PolicyEntity create(PolicyEntity policyEntity);
+
+    PolicyEntity update(PolicyEntity policyEntity);
+
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/PolicyEntityService.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/PolicyEntityService.java
@@ -19,7 +19,6 @@ package org.apache.eagle.metadata.service;
 
 import com.google.common.base.Preconditions;
 import org.apache.eagle.metadata.model.PolicyEntity;
-import org.apache.eagle.metadata.persistence.PersistenceService;
 
 import java.util.Collection;
 
@@ -33,7 +32,12 @@ public interface PolicyEntityService {
     boolean deletePolicyProtoByUUID(String uuid);
 
     default PolicyEntity createOrUpdatePolicyProto(PolicyEntity policyProto) {
-        Preconditions.checkNotNull(policyProto, "DashboardEntity should not be null");
+        Preconditions.checkNotNull(policyProto, "PolicyProto should not be null");
+        Preconditions.checkNotNull(policyProto.getDefinition(), "PolicyProto definition should not be null");
+        if (policyProto.getName() == null) {
+            policyProto.setName(String.format("[%s]%s", policyProto.getDefinition().getAlertCategory(),
+                    policyProto.getDefinition().getName()));
+        }
         if (policyProto.getUuid() == null) {
             return create(policyProto);
         } else {

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/memory/MemoryMetadataStore.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/memory/MemoryMetadataStore.java
@@ -22,6 +22,7 @@ import org.apache.eagle.alert.metadata.impl.InMemMetadataDaoImpl;
 import org.apache.eagle.metadata.persistence.MetadataStore;
 import org.apache.eagle.metadata.service.ApplicationEntityService;
 import org.apache.eagle.metadata.service.DashboardEntityService;
+import org.apache.eagle.metadata.service.PolicyEntityService;
 import org.apache.eagle.metadata.service.SiteEntityService;
 
 public class MemoryMetadataStore extends MetadataStore {
@@ -31,5 +32,6 @@ public class MemoryMetadataStore extends MetadataStore {
         bind(ApplicationEntityService.class).to(ApplicationEntityServiceMemoryImpl.class).in(Singleton.class);
         bind(IMetadataDao.class).to(InMemMetadataDaoImpl.class).in(Singleton.class);
         bind(DashboardEntityService.class).to(DashboardEntityServiceMemoryImpl.class).in(Singleton.class);
+        bind(PolicyEntityService.class).to(PolicyEntityServiceMemoryImpl.class).in(Singleton.class);
     }
 }

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/memory/PolicyEntityServiceMemoryImpl.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/service/memory/PolicyEntityServiceMemoryImpl.java
@@ -1,0 +1,62 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.service.memory;
+
+import com.google.common.base.Preconditions;
+import org.apache.eagle.metadata.model.PolicyEntity;
+import org.apache.eagle.metadata.service.PolicyEntityService;
+
+import java.util.Collection;
+import java.util.HashMap;
+
+public class PolicyEntityServiceMemoryImpl implements PolicyEntityService {
+    private HashMap<String, PolicyEntity> policyProtoMap = new HashMap<>();
+
+    @Override
+    public Collection<PolicyEntity> getAllPolicyProto() {
+        return policyProtoMap.values();
+    }
+
+    @Override
+    public PolicyEntity getPolicyProtoByUUID(String uuid) {
+        return policyProtoMap.get(uuid);
+    }
+
+    @Override
+    public boolean deletePolicyProtoByUUID(String uuid) {
+        policyProtoMap.remove(uuid);
+        return true;
+    }
+
+
+    @Override
+    public PolicyEntity create(PolicyEntity entity) {
+        Preconditions.checkNotNull(entity, "entity is null: " + entity);
+        entity.ensureDefault();
+        policyProtoMap.put(entity.getUuid(), entity);
+        return entity;
+    }
+
+    @Override
+    public PolicyEntity update(PolicyEntity policyEntity) {
+        Preconditions.checkNotNull(policyEntity, "entity is null: " + policyEntity);
+        Preconditions.checkNotNull(policyEntity.getUuid(), "uuid is null: " + policyEntity.getUuid());
+        policyProtoMap.put(policyEntity.getUuid(), policyEntity);
+        return policyEntity;
+    }
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/utils/PolicyIdConversions.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/main/java/org/apache/eagle/metadata/utils/PolicyIdConversions.java
@@ -1,0 +1,38 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.utils;
+
+import com.google.common.base.Preconditions;
+
+public class PolicyIdConversions {
+
+    public static String generateUniquePolicyId(String siteId, String policyName) {
+        return String.format("%s_%s", policyName, siteId);
+    }
+
+    public static String parsePolicyId(String siteId, String generatedUniquePolicyId) {
+        String subffix = String.format("_%s", siteId);
+        if (generatedUniquePolicyId.endsWith(subffix)) {
+            int streamTypeIdLength = generatedUniquePolicyId.length() - subffix.length();
+            Preconditions.checkArgument(streamTypeIdLength > 0, "Invalid policyId: " + generatedUniquePolicyId + ", policyId is empty");
+            return generatedUniquePolicyId.substring(0, streamTypeIdLength);
+        } else {
+            return generatedUniquePolicyId;
+        }
+    }
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/test/java/org/apache/eagle/metadata/service/TestPolicyEntityServiceMemoryImpl.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/test/java/org/apache/eagle/metadata/service/TestPolicyEntityServiceMemoryImpl.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 public class TestPolicyEntityServiceMemoryImpl {
 
-    PolicyEntityService policyEntityService = new PolicyEntityServiceMemoryImpl();
+    private PolicyEntityService policyEntityService = new PolicyEntityServiceMemoryImpl();
 
     @Test
     public void test() {
@@ -46,10 +46,10 @@ public class TestPolicyEntityServiceMemoryImpl {
         List<String> alertPublisherIds = Arrays.asList("slack");
 
         PolicyEntity policyEntity = new PolicyEntity();
-        policyEntity.setPolicyProto(policyDefinition);
+        policyEntity.setDefinition(policyDefinition);
         policyEntity.setAlertPublishmentIds(alertPublisherIds);
         PolicyEntity res = policyEntityService.createOrUpdatePolicyProto(policyEntity);
-        Assert.assertTrue(res.getPolicyProto().equals(policyDefinition));
+        Assert.assertTrue(res.getDefinition().equals(policyDefinition));
         Assert.assertTrue(CollectionUtils.isEqualCollection(res.getAlertPublishmentIds(), alertPublisherIds));
 
         Collection<PolicyEntity> policies =  policyEntityService.getAllPolicyProto();
@@ -59,9 +59,9 @@ public class TestPolicyEntityServiceMemoryImpl {
         Assert.assertTrue(entity.equals(policies.iterator().next()));
 
         // test update
-        entity.getPolicyProto().setName("policy2");
+        entity.getDefinition().setName("policy2");
         PolicyEntity updatedEntity = policyEntityService.update(entity);
-        Assert.assertTrue(updatedEntity.getPolicyProto().getName().equals("policy2"));
+        Assert.assertTrue(updatedEntity.getDefinition().getName().equals("policy2"));
 
 
         // test delete

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/test/java/org/apache/eagle/metadata/service/TestPolicyEntityServiceMemoryImpl.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/test/java/org/apache/eagle/metadata/service/TestPolicyEntityServiceMemoryImpl.java
@@ -1,0 +1,72 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.service;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.metadata.model.PolicyEntity;
+import org.apache.eagle.metadata.service.memory.PolicyEntityServiceMemoryImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class TestPolicyEntityServiceMemoryImpl {
+
+    PolicyEntityService policyEntityService = new PolicyEntityServiceMemoryImpl();
+
+    @Test
+    public void test() {
+        // define a prototype policy without site info
+        PolicyDefinition policyDefinition = new PolicyDefinition();
+        policyDefinition.setName("policy1");
+        PolicyDefinition.Definition definition = new PolicyDefinition.Definition("siddhi",
+                "from STREAM select * insert into out");
+        policyDefinition.setDefinition(definition);
+        policyDefinition.setInputStreams(Arrays.asList("STREAM"));
+        policyDefinition.setOutputStreams(Arrays.asList("out"));
+        // define publisher list
+        List<String> alertPublisherIds = Arrays.asList("slack");
+
+        PolicyEntity policyEntity = new PolicyEntity();
+        policyEntity.setPolicyProto(policyDefinition);
+        policyEntity.setAlertPublishmentIds(alertPublisherIds);
+        PolicyEntity res = policyEntityService.createOrUpdatePolicyProto(policyEntity);
+        Assert.assertTrue(res.getPolicyProto().equals(policyDefinition));
+        Assert.assertTrue(CollectionUtils.isEqualCollection(res.getAlertPublishmentIds(), alertPublisherIds));
+
+        Collection<PolicyEntity> policies =  policyEntityService.getAllPolicyProto();
+        Assert.assertTrue(policies.size() == 1);
+
+        PolicyEntity entity = policyEntityService.getPolicyProtoByUUID(policies.iterator().next().getUuid());
+        Assert.assertTrue(entity.equals(policies.iterator().next()));
+
+        // test update
+        entity.getPolicyProto().setName("policy2");
+        PolicyEntity updatedEntity = policyEntityService.update(entity);
+        Assert.assertTrue(updatedEntity.getPolicyProto().getName().equals("policy2"));
+
+
+        // test delete
+        //Assert.assertTrue(policyEntityService.deletePolicyProtoByUUID(entity.getUuid()));
+        policyEntityService.deletePolicyProtoByUUID(entity.getUuid());
+        Assert.assertTrue(policyEntityService.getAllPolicyProto().size() == 0);
+    }
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-base/src/test/java/org/apache/eagle/metadata/utils/PolicyIdConversionsTest.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-base/src/test/java/org/apache/eagle/metadata/utils/PolicyIdConversionsTest.java
@@ -1,0 +1,39 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PolicyIdConversionsTest {
+
+    @Test
+    public void testGenerateUniquePolicyId() {
+        Assert.assertEquals("mock_policy_test", PolicyIdConversions.generateUniquePolicyId("test", "mock_policy"));
+    }
+
+    @Test
+    public void testParsePolicyId() {
+        Assert.assertEquals("mock_policy", PolicyIdConversions.parsePolicyId("test", "mock_policy_test"));
+    }
+
+    @Test
+    public void testParsePolicyId2() {
+        Assert.assertEquals("mock_policy", PolicyIdConversions.parsePolicyId("test", "mock_policy"));
+    }
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/JDBCMetadataMetadataStoreServiceImpl.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/JDBCMetadataMetadataStoreServiceImpl.java
@@ -41,10 +41,11 @@ public class JDBCMetadataMetadataStoreServiceImpl implements JDBCMetadataQuerySe
     public boolean execute(String sql) throws SQLException {
         Connection connection = null;
         Statement statement = null;
+        boolean success = false;
         try {
             connection = dataSource.getConnection();
             statement = connection.createStatement();
-            return statement.execute(sql);
+            success = statement.execute(sql);
         } catch (SQLException e) {
             throw e;
         } finally {
@@ -63,6 +64,7 @@ public class JDBCMetadataMetadataStoreServiceImpl implements JDBCMetadataQuerySe
                 }
             }
         }
+        return success;
     }
 
     @Override

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/JDBCMetadataStore.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/JDBCMetadataStore.java
@@ -21,14 +21,17 @@ import com.google.inject.Singleton;
 import org.apache.eagle.alert.metadata.IMetadataDao;
 import org.apache.eagle.alert.metadata.MetadataUtils;
 import org.apache.eagle.alert.metadata.impl.JdbcMetadataDaoImpl;
+import org.apache.eagle.metadata.model.PolicyEntity;
 import org.apache.eagle.metadata.persistence.MetadataStore;
 import org.apache.eagle.metadata.service.ApplicationEntityService;
 import org.apache.eagle.metadata.service.DashboardEntityService;
+import org.apache.eagle.metadata.service.PolicyEntityService;
 import org.apache.eagle.metadata.service.SiteEntityService;
 import org.apache.eagle.metadata.store.jdbc.provider.JDBCDataSourceProvider;
 import org.apache.eagle.metadata.store.jdbc.provider.JDBCMetadataStoreConfigProvider;
 import org.apache.eagle.metadata.store.jdbc.service.ApplicationEntityServiceJDBCImpl;
 import org.apache.eagle.metadata.store.jdbc.service.DashboardEntityServiceJDBCImpl;
+import org.apache.eagle.metadata.store.jdbc.service.PolicyEntityServiceJDBCImpl;
 import org.apache.eagle.metadata.store.jdbc.service.SiteEntityServiceJDBCImpl;
 
 import javax.sql.DataSource;
@@ -43,5 +46,6 @@ public class JDBCMetadataStore extends MetadataStore {
         bind(ApplicationEntityService.class).to(ApplicationEntityServiceJDBCImpl.class).in(Singleton.class);
         bind(SiteEntityService.class).to(SiteEntityServiceJDBCImpl.class).in(Singleton.class);
         bind(DashboardEntityService.class).to(DashboardEntityServiceJDBCImpl.class).in(Singleton.class);
+        bind(PolicyEntityService.class).to(PolicyEntityServiceJDBCImpl.class).in(Singleton.class);
     }
 }

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/service/PolicyEntityServiceJDBCImpl.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/main/java/org/apache/eagle/metadata/store/jdbc/service/PolicyEntityServiceJDBCImpl.java
@@ -1,0 +1,180 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.store.jdbc.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.google.common.base.Preconditions;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.common.function.ThrowableConsumer2;
+import org.apache.eagle.common.function.ThrowableFunction;
+import org.apache.eagle.metadata.exceptions.EntityNotFoundException;
+import org.apache.eagle.metadata.model.PolicyEntity;
+import org.apache.eagle.metadata.service.PolicyEntityService;
+import org.apache.eagle.metadata.store.jdbc.JDBCMetadataQueryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class PolicyEntityServiceJDBCImpl implements PolicyEntityService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PolicyEntityServiceJDBCImpl.class);
+
+    private static final String selectSql = "SELECT * FROM policyProto";
+    private static final String queryByUUID = "SELECT * FROM policyProto where uuid = '%s'";
+    private static final String deleteSqlByUUID = "DELETE FROM policyProto where uuid = '%s'";
+    private static final String updateSqlByUUID = "UPDATE policyProto SET policyProto = ? , alertPublisherIds = ? , createdtime = ? , modifiedtime = ?  where uuid = ?";
+    private static final String insertSql = "INSERT INTO policyProto (policyProto, alertPublisherIds, createdtime, modifiedtime, uuid) VALUES (?, ?, ?, ?, ?)";
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Inject
+    JDBCMetadataQueryService queryService;
+
+    @Override
+    public Collection<PolicyEntity> getAllPolicyProto() {
+        try {
+            return queryService.query(selectSql, policyEntityMapper);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public PolicyEntity getPolicyProtoByUUID(String uuid) {
+        Preconditions.checkNotNull(uuid, "uuid should not be null");
+        try {
+            return queryService.query(String.format(queryByUUID, uuid), policyEntityMapper).stream()
+                    .findAny().orElseThrow(() -> new EntityNotFoundException("policyProto is not found by uuid"));
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public boolean deletePolicyProtoByUUID(String uuid) {
+        String sql = String.format(deleteSqlByUUID, uuid);
+        try {
+            return queryService.execute(sql);
+        } catch (Exception e) {
+            LOGGER.error("Error to execute {}: {}", sql, e);
+            throw new IllegalArgumentException("SQL execution error: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public PolicyEntity update(PolicyEntity policyProto) {
+        Preconditions.checkNotNull(policyProto, "Entity should not be null");
+        Preconditions.checkNotNull(policyProto.getUuid(), "uuid should not be null");
+        PolicyEntity current = getPolicyProtoByUUID(policyProto.getUuid());
+
+        if (policyProto.getAlertPublishmentIds() != null) {
+            current.setAlertPublishmentIds(policyProto.getAlertPublishmentIds());
+        }
+        if (policyProto.getPolicyProto() != null) {
+            current.setPolicyProto(policyProto.getPolicyProto());
+        }
+        current.ensureDefault();
+
+        try {
+            if (!queryService.execute(updateSqlByUUID, current, policyEntityWriter)) {
+                throw new IllegalArgumentException("Failed to update policyProto");
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Error to execute {}: {}", updateSqlByUUID, policyProto, e);
+            throw new IllegalArgumentException("SQL execution error: " + e.getMessage(), e);
+        }
+        return current;
+    }
+
+
+
+    @Override
+    public PolicyEntity create(PolicyEntity entity) {
+        Preconditions.checkNotNull(entity, "PolicyEntity should not be null");
+        entity.ensureDefault();
+        try {
+            int retCode = queryService.insert(insertSql, Collections.singletonList(entity), policyEntityWriter);
+            if (retCode > 0) {
+                return entity;
+            } else {
+                throw new SQLException("Insertion result: " + retCode);
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Error to insert entity {} (entity: {}): {}", insertSql, entity.toString(), e.getMessage(), e);
+            throw new IllegalArgumentException("SQL execution error:" + e.getMessage(), e);
+        }
+    }
+
+    private ThrowableFunction<ResultSet, PolicyEntity, SQLException> policyEntityMapper = resultSet -> {
+        PolicyEntity entity = new PolicyEntity();
+        entity.setUuid(resultSet.getString("uuid"));
+        String policyStr = resultSet.getString("policyProto");
+        if (policyStr != null) {
+            try {
+                PolicyDefinition policyDefinition = OBJECT_MAPPER.readValue(policyStr, PolicyDefinition.class);
+                entity.setPolicyProto(policyDefinition);
+            } catch (Exception e) {
+                throw new SQLException("Error to deserialize JSON as {}", PolicyDefinition.class.getCanonicalName(), e);
+            }
+        }
+        String list = resultSet.getString("alertPublisherIds");
+        if (list != null) {
+            try {
+                List<String> alertPublisherIds = OBJECT_MAPPER.readValue(list, List.class);
+                entity.setAlertPublishmentIds(alertPublisherIds);
+            } catch (Exception e) {
+                throw new SQLException("Error to deserialize JSON as AlertPublisherIds list", e);
+            }
+        }
+        entity.setCreatedTime(resultSet.getLong("createdtime"));
+        entity.setModifiedTime(resultSet.getLong("modifiedtime"));
+        return entity;
+    };
+
+    private ThrowableConsumer2<PreparedStatement, PolicyEntity, SQLException> policyEntityWriter = (statement, policyEntity) -> {
+        policyEntity.ensureDefault();
+
+        if (policyEntity.getPolicyProto() != null) {
+            try {
+                statement.setString(1, OBJECT_MAPPER.writeValueAsString(policyEntity.getPolicyProto()));
+            } catch (Exception e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
+        }
+        if (policyEntity.getAlertPublishmentIds() != null) {
+            try {
+                statement.setString(2, OBJECT_MAPPER.writeValueAsString(policyEntity.getAlertPublishmentIds()));
+            } catch (Exception e) {
+                throw new IllegalArgumentException(e.getMessage(), e);
+            }
+        }
+        statement.setLong(3, policyEntity.getCreatedTime());
+        statement.setLong(4, policyEntity.getModifiedTime());
+        statement.setString(5, policyEntity.getUuid());
+    };
+
+
+}
+

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/java/org/apache/eagle/metadata/store/jdbc/PolicyEntityServiceJDBCImplTest.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/java/org/apache/eagle/metadata/store/jdbc/PolicyEntityServiceJDBCImplTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 public class PolicyEntityServiceJDBCImplTest extends JDBCMetadataTestBase {
 
     @Inject
-    PolicyEntityService policyEntityService;
+    private PolicyEntityService policyEntityService;
 
     @Test
     public void test() {
@@ -48,11 +48,11 @@ public class PolicyEntityServiceJDBCImplTest extends JDBCMetadataTestBase {
         List<String> alertPublisherIds = Arrays.asList("slack");
 
         PolicyEntity policyEntity = new PolicyEntity();
-        policyEntity.setPolicyProto(policyDefinition);
+        policyEntity.setDefinition(policyDefinition);
         policyEntity.setAlertPublishmentIds(alertPublisherIds);
         PolicyEntity res = policyEntityService.createOrUpdatePolicyProto(policyEntity);
         Assert.assertTrue(res != null);
-        Assert.assertTrue(res.getPolicyProto().equals(policyDefinition));
+        Assert.assertTrue(res.getDefinition().equals(policyDefinition));
         Assert.assertTrue(CollectionUtils.isEqualCollection(res.getAlertPublishmentIds(), alertPublisherIds));
 
         Collection<PolicyEntity> policies =  policyEntityService.getAllPolicyProto();
@@ -62,9 +62,9 @@ public class PolicyEntityServiceJDBCImplTest extends JDBCMetadataTestBase {
         Assert.assertTrue(entity.equals(policies.iterator().next()));
 
         // test update
-        entity.getPolicyProto().setName("policy2");
+        entity.getDefinition().setName("policy2");
         PolicyEntity updatedEntity = policyEntityService.update(entity);
-        Assert.assertTrue(updatedEntity.getPolicyProto().getName().equals("policy2"));
+        Assert.assertTrue(updatedEntity.getDefinition().getName().equals("policy2"));
 
 
         // test delete

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/java/org/apache/eagle/metadata/store/jdbc/PolicyEntityServiceJDBCImplTest.java
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/java/org/apache/eagle/metadata/store/jdbc/PolicyEntityServiceJDBCImplTest.java
@@ -1,0 +1,76 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.eagle.metadata.store.jdbc;
+
+import com.google.inject.Inject;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.eagle.alert.engine.coordinator.PolicyDefinition;
+import org.apache.eagle.metadata.model.PolicyEntity;
+import org.apache.eagle.metadata.service.PolicyEntityService;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class PolicyEntityServiceJDBCImplTest extends JDBCMetadataTestBase {
+
+    @Inject
+    PolicyEntityService policyEntityService;
+
+    @Test
+    public void test() {
+        // define a prototype policy without site info
+        PolicyDefinition policyDefinition = new PolicyDefinition();
+        policyDefinition.setName("policy1");
+        PolicyDefinition.Definition definition = new PolicyDefinition.Definition("siddhi",
+                "from STREAM select * insert into out");
+        policyDefinition.setDefinition(definition);
+        policyDefinition.setInputStreams(Arrays.asList("STREAM"));
+        policyDefinition.setOutputStreams(Arrays.asList("out"));
+        // define publisher list
+        List<String> alertPublisherIds = Arrays.asList("slack");
+
+        PolicyEntity policyEntity = new PolicyEntity();
+        policyEntity.setPolicyProto(policyDefinition);
+        policyEntity.setAlertPublishmentIds(alertPublisherIds);
+        PolicyEntity res = policyEntityService.createOrUpdatePolicyProto(policyEntity);
+        Assert.assertTrue(res != null);
+        Assert.assertTrue(res.getPolicyProto().equals(policyDefinition));
+        Assert.assertTrue(CollectionUtils.isEqualCollection(res.getAlertPublishmentIds(), alertPublisherIds));
+
+        Collection<PolicyEntity> policies =  policyEntityService.getAllPolicyProto();
+        Assert.assertTrue(policies.size() == 1);
+
+        PolicyEntity entity = policyEntityService.getPolicyProtoByUUID(policies.iterator().next().getUuid());
+        Assert.assertTrue(entity.equals(policies.iterator().next()));
+
+        // test update
+        entity.getPolicyProto().setName("policy2");
+        PolicyEntity updatedEntity = policyEntityService.update(entity);
+        Assert.assertTrue(updatedEntity.getPolicyProto().getName().equals("policy2"));
+
+
+        // test delete
+        //Assert.assertTrue(policyEntityService.deletePolicyProtoByUUID(entity.getUuid()));
+        policyEntityService.deletePolicyProtoByUUID(entity.getUuid());
+        Assert.assertTrue(policyEntityService.getAllPolicyProto().size() == 0);
+    }
+
+}

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/resources/init.sql
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/resources/init.sql
@@ -55,11 +55,13 @@ CREATE TABLE IF NOT EXISTS `dashboards` (
   UNIQUE INDEX `name_UNIQUE` (`name` ASC))
 COMMENT = 'eagle dashboard metadata';
 
-CREATE TABLE IF NOT EXISTS `policyProto` (
+CREATE TABLE IF NOT EXISTS `policy_prototype` (
   `uuid` VARCHAR(50) NOT NULL,
-  `policyProto` longtext NOT NULL,
+  `name` VARCHAR(200) NOT NULL,
+  `definition` longtext NOT NULL,
   `alertPublisherIds` VARCHAR(500) NULL,
   `modifiedtime` BIGINT(20) NOT NULL,
   `createdtime` BIGINT(20) NOT NULL,
-  PRIMARY KEY (`uuid`))
+  PRIMARY KEY (`uuid`),
+  UNIQUE INDEX `policy_proto_UNIQUE` (`name` ASC))
 COMMENT = 'eagle policy prototype metadata';

--- a/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/resources/init.sql
+++ b/eagle-core/eagle-metadata/eagle-metadata-jdbc/src/test/resources/init.sql
@@ -54,3 +54,12 @@ CREATE TABLE IF NOT EXISTS `dashboards` (
   UNIQUE INDEX `uuid_UNIQUE` (`uuid` ASC),
   UNIQUE INDEX `name_UNIQUE` (`name` ASC))
 COMMENT = 'eagle dashboard metadata';
+
+CREATE TABLE IF NOT EXISTS `policyProto` (
+  `uuid` VARCHAR(50) NOT NULL,
+  `policyProto` longtext NOT NULL,
+  `alertPublisherIds` VARCHAR(500) NULL,
+  `modifiedtime` BIGINT(20) NOT NULL,
+  `createdtime` BIGINT(20) NOT NULL,
+  PRIMARY KEY (`uuid`))
+COMMENT = 'eagle policy prototype metadata';


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-1044'

Provided APIs:
*  load policies to new site "sandbox" from policy prototypes by `POST /rest/policyProto/loadToSite/sandbox`
* create a new policy prototype with an existing policy by `POST /rest/policyProto/saveAsProto`
* update or create a policy prototype by by `POST /rest/policyProto`
* get all policy prototypes by `GET /rest/policyProto`
* delete a policy prototype by `DELETE /rest/policyProto/{uuid}`
