### PR TITLE
EAGLE-1051: update removePolicy

### DIFF
--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/main/java/org/apache/eagle/alert/metadata/impl/JdbcMetadataDaoImpl.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/main/java/org/apache/eagle/alert/metadata/impl/JdbcMetadataDaoImpl.java
@@ -227,7 +227,8 @@ public class JdbcMetadataDaoImpl implements IMetadataDao {
 
     @Override
     public OpResult removePolicy(String policyId) {
-        return handler.removePolicyById(PolicyDefinition.class.getSimpleName(), policyId);
+        //return handler.removePolicyById(PolicyDefinition.class.getSimpleName(), policyId);
+        return handler.removeById(PolicyDefinition.class.getSimpleName(), policyId);
     }
 
     @Override

--- a/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/main/java/org/apache/eagle/alert/metadata/impl/JdbcMetadataHandler.java
+++ b/eagle-core/eagle-alert-parent/eagle-alert/alert-metadata-parent/alert-metadata/src/main/java/org/apache/eagle/alert/metadata/impl/JdbcMetadataHandler.java
@@ -455,36 +455,6 @@ public class JdbcMetadataHandler {
         return result;
     }
 
-    public OpResult removePolicyById(String clzName, String policyId) {
-        Connection connection = null;
-        PreparedStatement statement = null;
-        OpResult result = new OpResult();
-        try {
-            String tb = getTableName(clzName);
-            connection = dataSource.getConnection();
-            connection.setAutoCommit(false);
-            statement = connection.prepareStatement(String.format(DELETE_STATEMENT, tb));
-            statement.setString(1, policyId);
-            int status = statement.executeUpdate();
-            LOG.info("delete {} policy {} from {}", status, policyId, tb);
-            closeResource(null, statement, null);
-
-            statement = connection.prepareStatement(DELETE_PUBLISHMENT_STATEMENT);
-            statement.setString(1, policyId);
-            status = statement.executeUpdate();
-            LOG.info("delete {} records from policy_publishment", status);
-
-            connection.commit();
-            connection.setAutoCommit(true);
-        } catch (SQLException e) {
-            e.printStackTrace();
-        } finally {
-            closeResource(null, statement, connection);
-        }
-        LOG.info(result.message);
-        return result;
-    }
-
     public OpResult removeById(String clzName, String key) {
         Connection connection = null;
         PreparedStatement statement = null;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/EAGLE-1051

There is no need to do this check. As eagle has a table `policy_publishment` which has defined the relationship between policies and publishments. 

```
CREATE TABLE IF NOT EXISTS policy_publishment (
  policyId VARCHAR(50),
  publishmentName VARCHAR(50),
  PRIMARY KEY(policyId, publishmentName),
  CONSTRAINT `policy_id_fk` FOREIGN KEY (`policyId`) REFERENCES `policy_definition` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
  CONSTRAINT `publishment_id_fk` FOREIGN KEY (`publishmentName`) REFERENCES `publishment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
);
```

