### PR TITLE
adding missing apache license header

### DIFF
--- a/eagle-external/eagle-docker/resource/serf/bin/start-serf-agent.sh
+++ b/eagle-external/eagle-docker/resource/serf/bin/start-serf-agent.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 SERF_HOME=/usr/local/serf
 SERF_BIN=$SERF_HOME/bin/serf
 SERF_CONFIG_DIR=$SERF_HOME/etc


### PR DESCRIPTION
this is minor fix that adds apache license header to the following file