### PR TITLE
EAGLE-1074 - eagle-docker.sh uses the wrong path

### DIFF
--- a/eagle-external/eagle-docker/bin/eagle-docker.sh
+++ b/eagle-external/eagle-docker/bin/eagle-docker.sh
@@ -69,7 +69,7 @@ function build(){
 
 	# bringing it to a parent level
 	DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-	cd $DIR/../../../
+	cd $DIR/../../
 
 	# ==========================================
 	# Check Eagle Docker Image


### PR DESCRIPTION
<!--
{% comment %}
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to you under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
{% endcomment %}
-->

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[EAGLE-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---