### PR TITLE
EAGLE-1088: Change the inconsistent method name 'find'.

### DIFF
--- a/eagle-core/eagle-query/eagle-query-base/src/main/java/org/apache/eagle/query/aggregate/SortFieldOrderType.java
+++ b/eagle-core/eagle-query/eagle-query-base/src/main/java/org/apache/eagle/query/aggregate/SortFieldOrderType.java
@@ -51,7 +51,7 @@ public enum SortFieldOrderType {
     public static AggregateParams.SortFieldOrder matchAll(String sortFieldOrder) {
         for (SortFieldOrderType type : SortFieldOrderType.values()) {
             SortFieldOrderTypeMatcher m = type.matcher(sortFieldOrder);
-            if (m.find()) {
+            if (m.isMatched()) {
                 return m.sortFieldOrder();
             }
         }

--- a/eagle-core/eagle-query/eagle-query-base/src/main/java/org/apache/eagle/query/aggregate/SortFieldOrderTypeMatcher.java
+++ b/eagle-core/eagle-query/eagle-query-base/src/main/java/org/apache/eagle/query/aggregate/SortFieldOrderTypeMatcher.java
@@ -28,7 +28,7 @@ public class SortFieldOrderTypeMatcher {
         }
     }
 
-    public boolean find() {
+    public boolean isMatched() {
         return this.matched;
     }
 


### PR DESCRIPTION
Change the method name 'find' to 'isMatched'.
The method is named "find", but the method does not find anything, just returns a boolean-variable 'this.matched'. Thus, rename method as "isMatched" should be more clear than "find".